### PR TITLE
update with AADR v66 + added a crossref cache

### DIFF
--- a/base_script.py
+++ b/base_script.py
@@ -23,7 +23,30 @@ def load_supplementary_metadata():
 
 SUPPLEMENTARY_METADATA = load_supplementary_metadata()
 
+def load_crossref_cache():
+    if os.path.exists(CACHE_FILE):
+        try:
+            with open(CACHE_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            sys.stderr.write("WARNING: Failed to parse crossref_cache.json. Starting with empty cache.\n")
+    return {}
+
+def save_crossref_cache(cache):
+    with open(CACHE_FILE, "w", encoding="utf-8") as f:
+        json.dump(cache, f, indent=2, ensure_ascii=False)
+    print(f"Saved CrossRef cache to {CACHE_FILE}")
+
+CACHE_FILE = "crossref_cache.json"
+CROSSREF_CACHE = load_crossref_cache()
+
 def get_crossref_metadata(doi, index, total):
+
+    # Return cached metadata if available
+    if doi in CROSSREF_CACHE:
+        print(f"({index + 1} / {total}) Using cached metadata for {doi}")
+        return CROSSREF_CACHE[doi]
+
     print(f"({index + 1} / {total}) Gathering metadata for {doi}")
 
     #Initialize with supplementary.json 
@@ -74,6 +97,8 @@ def get_crossref_metadata(doi, index, total):
 
     #Fallback defaults
     metadata = {k: (v if v else get_default_value(k)) for k, v in metadata.items()}
+
+    CROSSREF_CACHE[doi] = metadata
 
     return metadata
 
@@ -380,6 +405,8 @@ unique_dois_data = check_for_duplicates(dois_data)
 # Get CrossRef metadata
 metadata_map = {entry["doi"]: get_crossref_metadata(entry["doi"], index, len(unique_dois_data))
                 for index, entry in enumerate(unique_dois_data)}
+
+save_crossref_cache(CROSSREF_CACHE)
 
 # Get Poseidon DOI availability
 poseidon_doi_map = load_poseidon_doi_map()

--- a/crossref_cache.json
+++ b/crossref_cache.json
@@ -1,0 +1,3106 @@
+{
+  "10.1038/s41467-026-70615-9": {
+    "title": "Analysis of medieval burials from Ibiza reveals genetic and pathogenic diversity during the Islamic period",
+    "year": 2026,
+    "journal": "Nature Communications",
+    "date": "2026-03-26",
+    "first_author": "Ricardo Rodríguez-Varela",
+    "doi_link": "https://doi.org/10.1038/s41467-026-70615-9"
+  },
+  "10.1038/s41559-026-03027-z": {
+    "title": "Population discontinuity in the Paris Basin linked to evidence of the Neolithic decline",
+    "year": 2026,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2026-04-03",
+    "first_author": "Frederik V. Seersholm",
+    "doi_link": "https://doi.org/10.1038/s41559-026-03027-z"
+  },
+  "10.1038/s41467-026-71457-1": {
+    "title": "Genetic genealogy of the Piast dynasty and related European royal families",
+    "year": 2026,
+    "journal": "Nature Communications",
+    "date": "2026-04-09",
+    "first_author": "Michal Zenczak",
+    "doi_link": "https://doi.org/10.1038/s41467-026-71457-1"
+  },
+  "10.1186/s13059-026-03968-5": {
+    "title": "Genetic affinities between the ancient Greek colony of Amvrakia and its metropolis",
+    "year": 2026,
+    "journal": "Genome Biology",
+    "date": "2026-02-07",
+    "first_author": "Nikolaos Psonis",
+    "doi_link": "https://doi.org/10.1186/s13059-026-03968-5"
+  },
+  "10.1098/rspb.2025.0813": {
+    "title": "Genetic relatedness mattered in the co-burial ritual of Neolithic hunter–gatherers",
+    "year": 2026,
+    "journal": "Proceedings of the Royal Society B: Biological Sciences",
+    "date": "2026-02-18",
+    "first_author": "Tiina Maria Mattila",
+    "doi_link": "https://doi.org/10.1098/rspb.2025.0813"
+  },
+  "10.1186/s13059-026-03969-4": {
+    "title": "Cosmopolitanism in the depths of Barbaricum evidenced by archaeogenomic data from the Late Iron Age Goth community of the Masłomęcz group",
+    "year": 2026,
+    "journal": "Genome Biology",
+    "date": "2026-01-28",
+    "first_author": "Michał Golubiński",
+    "doi_link": "https://doi.org/10.1186/s13059-026-03969-4"
+  },
+  "10.1038/s41562-025-02399-9": {
+    "title": "A large mass grave from the Early Iron Age indicates selective violence towards women and children in the Carpathian Basin",
+    "year": 2026,
+    "journal": "Nature Human Behaviour",
+    "date": "2026-02-23",
+    "first_author": "Linda Fibiger",
+    "doi_link": "https://doi.org/10.1038/s41562-025-02399-9"
+  },
+  "10.1038/s41467-026-69895-y": {
+    "title": "Reconstruction of the lifeways of Central European Late Bronze Age communities using ancient DNA, isotope and osteoarchaeological analyses",
+    "year": 2026,
+    "journal": "Nature Communications",
+    "date": "2026-02-24",
+    "first_author": "Eleftheria Orfanou",
+    "doi_link": "https://doi.org/10.1038/s41467-026-69895-y"
+  },
+  "10.1016/j.cub.2026.02.004": {
+    "title": "Ancient genomes provide insight into the Paleolithic-to-Neolithic transition in northern East Asia",
+    "year": 2026,
+    "journal": "Current Biology",
+    "date": "2026-03-04",
+    "first_author": "Ganyu Zhang",
+    "doi_link": "https://doi.org/10.1016/j.cub.2026.02.004"
+  },
+  "10.1038/s41586-026-10233-z": {
+    "title": "Local agricultural transition, crisis and migration in the Southern Andes",
+    "year": 2026,
+    "journal": "Nature",
+    "date": "2026-03-18",
+    "first_author": "Ramiro Barberena",
+    "doi_link": "https://doi.org/10.1038/s41586-026-10233-z"
+  },
+  "10.1038/s41586-026-10111-8": {
+    "title": "Lasting Lower Rhine–Meuse forager ancestry shaped Bell Beaker expansion",
+    "year": 2026,
+    "journal": "Nature",
+    "date": "2026-02-11",
+    "first_author": "Iñigo Olalde",
+    "doi_link": "https://doi.org/10.1038/s41586-026-10111-8"
+  },
+  "10.1038/s41586-025-09856-5": {
+    "title": "An ancient DNA perspective on the Russian conquest of Yakutia",
+    "year": 2026,
+    "journal": "Nature",
+    "date": "2026-01-07",
+    "first_author": "Éric Crubézy",
+    "doi_link": "https://doi.org/10.1038/s41586-025-09856-5"
+  },
+  "10.1101/2025.11.03.686206": {
+    "title": "Genetic insights into Iron Age Saka culture: Ancient DNA analysis of the Boz-Barmak burial ground, Kyrgyzstan",
+    "year": 0,
+    "journal": "No Journal",
+    "date": "2025-11-04",
+    "first_author": "Aigerim Rymbekova",
+    "doi_link": "https://doi.org/10.1101/2025.11.03.686206"
+  },
+  "10.1038/s41586-025-09799-x": {
+    "title": "Ancient DNA from Shimao city records kinship practices in Neolithic China",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-11-26",
+    "first_author": "Zehui Chen",
+    "doi_link": "https://doi.org/10.1038/s41586-025-09799-x"
+  },
+  "10.1038/s41586-025-09811-4": {
+    "title": "Homo sapiens-specific evolution unveiled by ancient southern African genomes",
+    "year": 2026,
+    "journal": "Nature",
+    "date": "2025-12-03",
+    "first_author": "Mattias Jakobsson",
+    "doi_link": "https://doi.org/10.1038/s41586-025-09811-4"
+  },
+  "10.64898/2025.12.07.692553": {
+    "title": "Ancestry, admixture, and pathogens in contemporaneous Neolithic farmers and foragers on the Island of Gotland",
+    "year": 0,
+    "journal": "No Journal",
+    "date": "2025-12-10",
+    "first_author": "Magdalena Fraser",
+    "doi_link": "https://doi.org/10.64898/2025.12.07.692553"
+  },
+  "10.1038/s41467-025-67906-y": {
+    "title": "Tracing social mechanisms and interregional connections in Early Bronze Age Societies in Lower Austria",
+    "year": 2025,
+    "journal": "Nature Communications",
+    "date": "2025-12-31",
+    "first_author": "Anja Furtwängler",
+    "doi_link": "https://doi.org/10.1038/s41467-025-67906-y"
+  },
+  "10.1038/s42003-025-09194-2": {
+    "title": "Archaeogenetics reconstructs demography and extreme parental consanguinity in a Bronze Age community from Southern Italy",
+    "year": 2025,
+    "journal": "Communications Biology",
+    "date": "2025-12-15",
+    "first_author": "Francesco Fontani",
+    "doi_link": "https://doi.org/10.1038/s42003-025-09194-2"
+  },
+  "10.1016/j.jasrep.2025.105559": {
+    "title": "Genetic and historical perspectives on the early medieval inhumations from the Menga dolmen, Antequera (Spain)",
+    "year": 2026,
+    "journal": "Journal of Archaeological Science: Reports",
+    "date": "2025-12-24",
+    "first_author": "Marina Silva",
+    "doi_link": "https://doi.org/10.1016/j.jasrep.2025.105559"
+  },
+  "10.1016/j.jasrep.2025.105474": {
+    "title": "Ancient genomic evidence uncovers a 6th-century cross-border couple between South Asia and East Asia",
+    "year": 2025,
+    "journal": "Journal of Archaeological Science: Reports",
+    "date": "2025-11-05",
+    "first_author": "Panxin Du",
+    "doi_link": "https://doi.org/10.1016/j.jasrep.2025.105474"
+  },
+  "10.1016/j.cell.2025.09.002": {
+    "title": "Long shared haplotypes identify the southern Urals as a primary source for the 10th-century Hungarians",
+    "year": 2025,
+    "journal": "Cell",
+    "date": "2025-10-16",
+    "first_author": "Balázs Gyuris",
+    "doi_link": "https://doi.org/10.1016/j.cell.2025.09.002"
+  },
+  "10.1016/j.cub.2025.09.047": {
+    "title": "Paratyphoid fever and relapsing fever in 1812 Napoleon's devastated army",
+    "year": 2025,
+    "journal": "Current Biology",
+    "date": "2025-10-24",
+    "first_author": "Rémi Barbieri",
+    "doi_link": "https://doi.org/10.1016/j.cub.2025.09.047"
+  },
+  "10.1038/s41598-025-21522-4": {
+    "title": "Genome of an early Okhotsk individual reveals ancient admixture between Jomon and Kamchatka lineages",
+    "year": 2025,
+    "journal": "Scientific Reports",
+    "date": "2025-10-27",
+    "first_author": "Takehiro Sato",
+    "doi_link": "https://doi.org/10.1038/s41598-025-21522-4"
+  },
+  "10.1016/j.fsigen.2025.103381": {
+    "title": "Murder in cold blood? Forensic and bioarchaeological identification of the skeletal remains of Béla, Duke of Macsó (c. 1245–1272)",
+    "year": 2026,
+    "journal": "Forensic Science International: Genetics",
+    "date": "2025-10-26",
+    "first_author": "Tamás Hajdu",
+    "doi_link": "https://doi.org/10.1016/j.fsigen.2025.103381"
+  },
+  "10.1126/sciadv.adu9625": {
+    "title": "Dynamic human admixture histories over the past ~1300 years at the northern Himalayan frontier",
+    "year": 2025,
+    "journal": "Science Advances",
+    "date": "2025-10-29",
+    "first_author": "Esha Bandyopadhyay",
+    "doi_link": "https://doi.org/10.1126/sciadv.adu9625"
+  },
+  "10.1038/s41586-025-09731-3": {
+    "title": "Eight millennia of continuity of a previously unknown lineage in Argentina",
+    "year": 2026,
+    "journal": "Nature",
+    "date": "2025-11-05",
+    "first_author": "Javier Maravall-López",
+    "doi_link": "https://doi.org/10.1038/s41586-025-09731-3"
+  },
+  "10.1038/s41586-025-09437-6": {
+    "title": "Ancient DNA connects large-scale migration with the spread of Slavs",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-09-03",
+    "first_author": "Joscha Gretzinger",
+    "doi_link": "https://doi.org/10.1038/s41586-025-09437-6"
+  },
+  "10.1186/s13059-025-03700-9": {
+    "title": "Ancient genomes provide evidence of demographic shift to Slavic-associated groups in Moravia",
+    "year": 2025,
+    "journal": "Genome Biology",
+    "date": "2025-09-03",
+    "first_author": "Ilektra Schulz",
+    "doi_link": "https://doi.org/10.1186/s13059-025-03700-9"
+  },
+  "10.1371/journal.pone.0333440": {
+    "title": "Multidisciplinary study of human remains from the 3rd century mass grave in the Roman city of Mursa, Croatia",
+    "year": 2025,
+    "journal": "PLOS One",
+    "date": "2025-10-15",
+    "first_author": "Mario Novak",
+    "doi_link": "https://doi.org/10.1371/journal.pone.0333440"
+  },
+  "10.1126/sciadv.adw8219": {
+    "title": "Ancient genomes from eastern Kazakhstan reveal dynamic genetic legacy of Inner Eurasian hunter-gatherers",
+    "year": 2025,
+    "journal": "Science Advances",
+    "date": "2025-10-15",
+    "first_author": "Haechan Gill",
+    "doi_link": "https://doi.org/10.1126/sciadv.adw8219"
+  },
+  "10.1038/s41467-025-63789-1": {
+    "title": "Slab Grave expansion disrupted long co-existence of distinct Bronze Age herders in central Mongolia",
+    "year": 2025,
+    "journal": "Nature Communications",
+    "date": "2025-09-25",
+    "first_author": "Juhyeon Lee",
+    "doi_link": "https://doi.org/10.1038/s41467-025-63789-1"
+  },
+  "10.1038/s41467-025-63743-1": {
+    "title": "Ancient DNA reveals the population interactions and a Neolithic patrilineal community in Northern Yangtze Region",
+    "year": 2025,
+    "journal": "Nature Communications",
+    "date": "2025-09-30",
+    "first_author": "Tingyu Yang",
+    "doi_link": "https://doi.org/10.1038/s41467-025-63743-1"
+  },
+  "10.1038/s42003-025-08668-7": {
+    "title": "Genomic insights from a final Bronze Age community buried in a collective tumulus in an Urnfield settlement in Northeastern Iberia",
+    "year": 2025,
+    "journal": "Communications Biology",
+    "date": "2025-08-28",
+    "first_author": "Marina Bretos Ezcurra",
+    "doi_link": "https://doi.org/10.1038/s42003-025-08668-7"
+  },
+  "10.1016/j.isci.2025.113086": {
+    "title": "Archaeogenetics reveals fine-scale genetic continuity and patterns of kinship and health in medieval Finland",
+    "year": 2025,
+    "journal": "iScience",
+    "date": "2025-07-15",
+    "first_author": "Ulla Nordfors",
+    "doi_link": "https://doi.org/10.1016/j.isci.2025.113086"
+  },
+  "10.1016/j.cub.2025.06.054": {
+    "title": "Bronze and Iron Age genomes reveal the integration of diverse ancestries in the Tarim Basin",
+    "year": 2025,
+    "journal": "Current Biology",
+    "date": "2025-07-17",
+    "first_author": "Fan Zhang",
+    "doi_link": "https://doi.org/10.1016/j.cub.2025.06.054"
+  },
+  "10.1126/sciadv.ads8179": {
+    "title": "Genetic history of Scythia",
+    "year": 2025,
+    "journal": "Science Advances",
+    "date": "2025-07-23",
+    "first_author": "Tatiana V. Andreeva",
+    "doi_link": "https://doi.org/10.1126/sciadv.ads8179"
+  },
+  "10.1093/gbe/evaf149": {
+    "title": "A New Perspective on the Arrival of the Eastern Mediterranean Genetic Influx in Central Italy Before the Onset of the Roman Empire",
+    "year": 2025,
+    "journal": "Genome Biology and Evolution",
+    "date": "2025-07-26",
+    "first_author": "Francesco Ravasini",
+    "doi_link": "https://doi.org/10.1093/gbe/evaf149"
+  },
+  "10.1016/j.cell.2025.07.013": {
+    "title": "The genetic history of the Southern Caucasus from the Bronze Age to the Early Middle Ages: 5,000 years of genetic continuity despite high mobility",
+    "year": 2025,
+    "journal": "Cell",
+    "date": "2025-08-07",
+    "first_author": "Eirini Skourtanioti",
+    "doi_link": "https://doi.org/10.1016/j.cell.2025.07.013"
+  },
+  "10.1038/s41586-025-09195-5": {
+    "title": "Whole-genome ancestry of an Old Kingdom Egyptian",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-07-02",
+    "first_author": "Adeline Morez Jacobs",
+    "doi_link": "https://doi.org/10.1038/s41586-025-09195-5"
+  },
+  "10.1016/j.isci.2025.112871": {
+    "title": "Genetic transitions in the Neolithic and Bronze Age at Mas d’en Boixos (Catalonia, Spain)",
+    "year": 2025,
+    "journal": "iScience",
+    "date": "2025-06-11",
+    "first_author": "Xavier Roca-Rada",
+    "doi_link": "https://doi.org/10.1016/j.isci.2025.112871"
+  },
+  "10.1038/s41586-025-09189-3": {
+    "title": "Ancient DNA reveals the prehistory of the Uralic and Yeniseian peoples",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-07-02",
+    "first_author": "Tian Chen Zeng",
+    "doi_link": "https://doi.org/10.1038/s41586-025-09189-3"
+  },
+  "10.1038/s41467-025-61601-8": {
+    "title": "Genomic diversity and structure of prehistoric alpine individuals from the Tyrolean Iceman’s territory",
+    "year": 2025,
+    "journal": "Nature Communications",
+    "date": "2025-07-11",
+    "first_author": "Myriam Croze",
+    "doi_link": "https://doi.org/10.1038/s41467-025-61601-8"
+  },
+  "10.1126/sciadv.adq9976": {
+    "title": "Local increases in admixture with hunter-gatherers followed the initial expansion of Neolithic farmers across continental Europe",
+    "year": 2025,
+    "journal": "Science Advances",
+    "date": "2025-08-20",
+    "first_author": "Alexandros Tsoupas",
+    "doi_link": "https://doi.org/10.1126/sciadv.adq9976"
+  },
+  "10.1186/s13059-025-03707-2": {
+    "title": "The genetic history of Portugal over the past 5,000 years",
+    "year": 2025,
+    "journal": "Genome Biology",
+    "date": "2025-08-18",
+    "first_author": "Xavier Roca-Rada",
+    "doi_link": "https://doi.org/10.1186/s13059-025-03707-2"
+  },
+  "10.1016/j.cell.2022.03.007": {
+    "title": "Ancient genomes reveal origin and rapid trans-Eurasian migration of 7th century Avar elites",
+    "year": 2022,
+    "journal": "Cell",
+    "date": "2022-04-01",
+    "first_author": "Guido Alberto Gnecchi-Ruscone",
+    "doi_link": "https://doi.org/10.1016/j.cell.2022.03.007"
+  },
+  "10.1038/s41559-022-01952-3": {
+    "title": "Ancient DNA reveals admixture history and endogamy in the prehistoric Aegean",
+    "year": 2023,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2023-01-16",
+    "first_author": "Eirini Skourtanioti",
+    "doi_link": "https://doi.org/10.1038/s41559-022-01952-3"
+  },
+  "10.1126/science.adr2915": {
+    "title": "Female lineages and changing kinship patterns in Neolithic Çatalhöyük",
+    "year": 2025,
+    "journal": "Science",
+    "date": "2025-06-26",
+    "first_author": "Eren Yüncü",
+    "doi_link": "https://doi.org/10.1126/science.adr2915"
+  },
+  "10.1126/science.adr3326": {
+    "title": "Out-of-Anatolia: Cultural and genetic interactions during the Neolithic expansion in the Aegean",
+    "year": 2025,
+    "journal": "Science",
+    "date": "2025-06-26",
+    "first_author": "Dilek Koptekin",
+    "doi_link": "https://doi.org/10.1126/science.adr3326"
+  },
+  "10.1038/s41467-025-60368-2": {
+    "title": "Ancient DNA reveals diverse community organizations in the 5th millennium BCE Carpathian Basin",
+    "year": 2025,
+    "journal": "Nature Communications",
+    "date": "2025-06-24",
+    "first_author": "Anna Szécsényi-Nagy",
+    "doi_link": "https://doi.org/10.1038/s41467-025-60368-2"
+  },
+  "10.1038/s41598-025-99743-w": {
+    "title": "Ancient DNA indicates 3,000 years of genetic continuity in the Northern Iranian Plateau, from the Copper Age to the Sassanid Empire",
+    "year": 2025,
+    "journal": "Scientific Reports",
+    "date": "2025-05-13",
+    "first_author": "Motahareh Ala Amjadi",
+    "doi_link": "https://doi.org/10.1038/s41598-025-99743-w"
+  },
+  "10.1016/j.cell.2025.05.009": {
+    "title": "Unveiling the origins and genetic makeup of the “forgotten people”: A study of the Sarmatian-period population in the Carpathian Basin",
+    "year": 2025,
+    "journal": "Cell",
+    "date": "2025-06-10",
+    "first_author": "Oszkár Schütz",
+    "doi_link": "https://doi.org/10.1016/j.cell.2025.05.009"
+  },
+  "10.1038/s41586-025-09103-x": {
+    "title": "Ancient DNA reveals a two-clanned matrilineal community in Neolithic China",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-06-04",
+    "first_author": "Jincheng Wang",
+    "doi_link": "https://doi.org/10.1038/s41586-025-09103-x"
+  },
+  "10.1038/s41559-025-02710-x": {
+    "title": "The impact of human dispersals and local interactions on the genetic diversity of coastal Papua New Guinea over the past 2,500 years",
+    "year": 2025,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2025-06-04",
+    "first_author": "Kathrin Nägele",
+    "doi_link": "https://doi.org/10.1038/s41559-025-02710-x"
+  },
+  "10.1186/s13059-025-03580-z": {
+    "title": "Urbanization and genetic homogenization in the medieval Low Countries revealed through a ten-century paleogenomic study of the city of Sint-Truiden",
+    "year": 2025,
+    "journal": "Genome Biology",
+    "date": "2025-05-19",
+    "first_author": "Owyn Beneker",
+    "doi_link": "https://doi.org/10.1186/s13059-025-03580-z"
+  },
+  "10.1126/science.adk5081": {
+    "title": "From North Asia to South America: Tracing the longest human migration through genomic sequencing",
+    "year": 2025,
+    "journal": "Science",
+    "date": "2025-05-29",
+    "first_author": "Elena S. Gusareva",
+    "doi_link": "https://doi.org/10.1126/science.adk5081"
+  },
+  "10.1126/sciadv.adr0695": {
+    "title": "North Pontic crossroads: Mobility in Ukraine from the Bronze Age to the early modern period",
+    "year": 2025,
+    "journal": "Science Advances",
+    "date": "2025-01-08",
+    "first_author": "Lehti Saag",
+    "doi_link": "https://doi.org/10.1126/sciadv.adr0695"
+  },
+  "10.1186/s13059-025-03570-1": {
+    "title": "Medieval genomes from eastern Iberia illuminate the role of Morisco mass deportations in dismantling a long-standing genetic bridge with North Africa",
+    "year": 2025,
+    "journal": "Genome Biology",
+    "date": "2025-04-28",
+    "first_author": "Gonzalo Oteo-Garcia",
+    "doi_link": "https://doi.org/10.1186/s13059-025-03570-1"
+  },
+  "10.1038/s41467-025-56555-w": {
+    "title": "East Asian Gene flow bridged by northern coastal populations over past 6000 years",
+    "year": 2025,
+    "journal": "Nature Communications",
+    "date": "2025-02-03",
+    "first_author": "Juncen Liu",
+    "doi_link": "https://doi.org/10.1038/s41467-025-56555-w"
+  },
+  "10.1038/s41586-024-08418-5": {
+    "title": "Ancient DNA reveals reproductive barrier despite shared Avar-period culture",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-01-15",
+    "first_author": "Ke Wang",
+    "doi_link": "https://doi.org/10.1038/s41586-024-08418-5"
+  },
+  "10.1038/s41586-024-08409-6": {
+    "title": "Continental influx and pervasive matrilocality in Iron Age Britain",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-01-15",
+    "first_author": "Lara M. Cassidy",
+    "doi_link": "https://doi.org/10.1038/s41586-024-08409-6"
+  },
+  "10.1038/s41586-024-07651-2": {
+    "title": "Repeated plague infections across six generations of Neolithic Farmers",
+    "year": 2024,
+    "journal": "Nature",
+    "date": "2024-07-10",
+    "first_author": "Frederik Valeur Seersholm",
+    "doi_link": "https://doi.org/10.1038/s41586-024-07651-2"
+  },
+  "10.1038/s42003-020-01627-4": {
+    "title": "Genome-wide study of a Neolithic Wartberg grave community reveals distinct HLA variation and hunter-gatherer ancestry",
+    "year": 2021,
+    "journal": "Communications Biology",
+    "date": "2021-01-25",
+    "first_author": "Alexander Immel",
+    "doi_link": "https://doi.org/10.1038/s42003-020-01627-4"
+  },
+  "10.1038/s41562-024-02034-z": {
+    "title": "Social and genetic diversity in first farmers of central Europe",
+    "year": 2024,
+    "journal": "Nature Human Behaviour",
+    "date": "2024-11-29",
+    "first_author": "Pere Gelabert",
+    "doi_link": "https://doi.org/10.1038/s41562-024-02034-z"
+  },
+  "10.1186/s12915-024-02068-9": {
+    "title": "Ancient genomes from the Tang Dynasty capital reveal the genetic legacy of trans-Eurasian communication at the eastern end of Silk Road",
+    "year": 2024,
+    "journal": "BMC Biology",
+    "date": "2024-11-20",
+    "first_author": "Minglei Lv",
+    "doi_link": "https://doi.org/10.1186/s12915-024-02068-9"
+  },
+  "10.1186/s13059-024-03430-4": {
+    "title": "The genomic portrait of the Picene culture provides new insights into the Italic Iron Age and the legacy of the Roman Empire in Central Italy",
+    "year": 2024,
+    "journal": "Genome Biology",
+    "date": "2024-11-20",
+    "first_author": "Francesco Ravasini",
+    "doi_link": "https://doi.org/10.1186/s13059-024-03430-4"
+  },
+  "10.1038/s41467-024-51150-x": {
+    "title": "Life history and ancestry of the late Upper Palaeolithic infant from Grotta delle Mura, Italy",
+    "year": 2024,
+    "journal": "Nature Communications",
+    "date": "2024-09-20",
+    "first_author": "Owen Alexander Higgins",
+    "doi_link": "https://doi.org/10.1038/s41467-024-51150-x"
+  },
+  "10.1016/j.cub.2024.07.063": {
+    "title": "Genomic dynamics of the Lower Yellow River Valley since the Early Neolithic",
+    "year": 2024,
+    "journal": "Current Biology",
+    "date": "2024-08-14",
+    "first_author": "Panxin Du",
+    "doi_link": "https://doi.org/10.1016/j.cub.2024.07.063"
+  },
+  "10.1038/s41586-024-07881-4": {
+    "title": "Ancient Rapanui genomes reveal resilience and pre-European contact with the Americas",
+    "year": 2024,
+    "journal": "Nature",
+    "date": "2024-09-11",
+    "first_author": "J. Víctor Moreno-Mayar",
+    "doi_link": "https://doi.org/10.1038/s41586-024-07881-4"
+  },
+  "10.1016/j.xgen.2024.100593": {
+    "title": "Long genetic and social isolation in Neanderthals before their extinction",
+    "year": 2024,
+    "journal": "Cell Genomics",
+    "date": "2024-09-11",
+    "first_author": "Ludovic Slimak",
+    "doi_link": "https://doi.org/10.1016/j.xgen.2024.100593"
+  },
+  "10.1126/sciadv.adp8625": {
+    "title": "Five centuries of consanguinity, isolation, health, and conflict in Las Gobas: A Northern Medieval Iberian necropolis",
+    "year": 2024,
+    "journal": "Science Advances",
+    "date": "2024-08-28",
+    "first_author": "Ricardo Rodríguez-Varela",
+    "doi_link": "https://doi.org/10.1126/sciadv.adp8625"
+  },
+  "10.1038/s41586-025-08793-7": {
+    "title": "Ancient DNA from the Green Sahara reveals ancestral North African lineage",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-04-04",
+    "first_author": "Nada Salem",
+    "doi_link": "https://doi.org/10.1038/s41586-025-08793-7"
+  },
+  "10.1038/s41586-025-08913-3": {
+    "title": "Punic people were genetically diverse with almost no Levantine ancestors",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-04-23",
+    "first_author": "Harald Ringbauer",
+    "doi_link": "https://doi.org/10.1038/s41586-025-08913-3"
+  },
+  "10.1038/s41586-024-08531-5": {
+    "title": "The genetic origin of the Indo-Europeans",
+    "year": 2025,
+    "journal": "Nature",
+    "date": "2025-02-05",
+    "first_author": "Iosif Lazaridis",
+    "doi_link": "https://doi.org/10.1038/s41586-024-08531-5"
+  },
+  "10.1002/ajpa.23312": {
+    "title": "Testing support for the northern and southern dispersal routes out of Africa: an analysis of Levantine and southern Arabian populations",
+    "year": 2017,
+    "journal": "American Journal of Physical Anthropology",
+    "date": "2017-09-15",
+    "first_author": "Deven N. Vyas",
+    "doi_link": "https://doi.org/10.1002/ajpa.23312"
+  },
+  "10.1002/ajpa.24079": {
+    "title": "The Neolithic Pitted Ware culture foragers were culturally but not genetically influenced by the Battle Axe culture herders",
+    "year": 2020,
+    "journal": "American Journal of Physical Anthropology",
+    "date": "2020-06-04",
+    "first_author": "Alexandra Coutinho",
+    "doi_link": "https://doi.org/10.1002/ajpa.24079"
+  },
+  "10.1016/j.ajhg.2017.06.013": {
+    "title": "Continuity and Admixture in the Last Five Millennia of Levantine History from Ancient Canaanite and Present-Day Lebanese Genome Sequences",
+    "year": 2017,
+    "journal": "The American Journal of Human Genetics",
+    "date": "2017-07-27",
+    "first_author": "Marc Haber",
+    "doi_link": "https://doi.org/10.1016/j.ajhg.2017.06.013"
+  },
+  "10.1016/j.ajhg.2020.05.008": {
+    "title": "A Genetic History of the Near East from an aDNA Time Course Sampling Eight Points in the Past 4,000 Years",
+    "year": 2020,
+    "journal": "The American Journal of Human Genetics",
+    "date": "2020-05-28",
+    "first_author": "Marc Haber",
+    "doi_link": "https://doi.org/10.1016/j.ajhg.2020.05.008"
+  },
+  "10.1016/j.cell.2017.08.049": {
+    "title": "Reconstructing Prehistoric African Population Structure",
+    "year": 2017,
+    "journal": "Cell",
+    "date": "2017-09-21",
+    "first_author": "Pontus Skoglund",
+    "doi_link": "https://doi.org/10.1016/j.cell.2017.08.049"
+  },
+  "10.1016/j.cell.2020.10.015": {
+    "title": "A Dynamic 6,000-Year Genetic History of Eurasia’s Eastern Steppe",
+    "year": 2020,
+    "journal": "Cell",
+    "date": "2020-11-05",
+    "first_author": "Choongwon Jeong",
+    "doi_link": "https://doi.org/10.1016/j.cell.2020.10.015"
+  },
+  "10.1016/j.cell.2021.02.040": {
+    "title": "Archaeogenomic distinctiveness of the Isthmo-Colombian area",
+    "year": 2021,
+    "journal": "Cell",
+    "date": "2021-03-23",
+    "first_author": "Marco Rosario Capodiferro",
+    "doi_link": "https://doi.org/10.1016/j.cell.2021.02.040"
+  },
+  "10.1016/j.cell.2021.03.039": {
+    "title": "The genomic history of the Aegean palatial civilizations",
+    "year": 2021,
+    "journal": "Cell",
+    "date": "2021-04-29",
+    "first_author": "Florian Clemente",
+    "doi_link": "https://doi.org/10.1016/j.cell.2021.03.039"
+  },
+  "10.1016/j.cell.2021.04.040": {
+    "title": "The deep population history of northern East Asia from the Late Pleistocene to the Holocene",
+    "year": 2021,
+    "journal": "Cell",
+    "date": "2021-05-27",
+    "first_author": "Xiaowei Mao",
+    "doi_link": "https://doi.org/10.1016/j.cell.2021.04.040"
+  },
+  "10.1016/j.cub.2014.09.078": {
+    "title": "Two ancient human genomes reveal Polynesian ancestry among the indigenous Botocudos of Brazil",
+    "year": 2014,
+    "journal": "Current Biology",
+    "date": "2014-10-24",
+    "first_author": "Anna-Sapfo Malaspinas",
+    "doi_link": "https://doi.org/10.1016/j.cub.2014.09.078"
+  },
+  "10.1016/j.cub.2015.12.019": {
+    "title": "Genomic Evidence Establishes Anatolia as the Source of the European Neolithic Gene Pool",
+    "year": 2016,
+    "journal": "Current Biology",
+    "date": "2015-12-31",
+    "first_author": "Ayça Omrak",
+    "doi_link": "https://doi.org/10.1016/j.cub.2015.12.019"
+  },
+  "10.1016/j.cub.2016.07.057": {
+    "title": "The Demographic Development of the First Farmers in Anatolia",
+    "year": 2016,
+    "journal": "Current Biology",
+    "date": "2016-08-05",
+    "first_author": "Gülşah Merve Kılınç",
+    "doi_link": "https://doi.org/10.1016/j.cub.2016.07.057"
+  },
+  "10.1016/j.cub.2016.12.060": {
+    "title": "The Neolithic Transition in the Baltic Was Not Driven by Admixture with Early European Farmers",
+    "year": 2017,
+    "journal": "Current Biology",
+    "date": "2017-02-03",
+    "first_author": "Eppie R. Jones",
+    "doi_link": "https://doi.org/10.1016/j.cub.2016.12.060"
+  },
+  "10.1016/j.cub.2017.05.023": {
+    "title": "Paleogenomic Evidence for Multi-generational Mixing between Neolithic Farmers and Mesolithic Hunter-Gatherers in the Lower Danube Basin",
+    "year": 2017,
+    "journal": "Current Biology",
+    "date": "2017-05-25",
+    "first_author": "Gloria González-Fortes",
+    "doi_link": "https://doi.org/10.1016/j.cub.2017.05.023"
+  },
+  "10.1016/j.cub.2017.06.022": {
+    "title": "Extensive Farming in Estonia Started through a Sex-Biased Migration from the Steppe",
+    "year": 2017,
+    "journal": "Current Biology",
+    "date": "2017-07-14",
+    "first_author": "Lehti Saag",
+    "doi_link": "https://doi.org/10.1016/j.cub.2017.06.022"
+  },
+  "10.1016/j.cub.2017.09.030": {
+    "title": "40,000-Year-Old Individual from Asia Provides Insight into Early Population Structure in Eurasia",
+    "year": 2017,
+    "journal": "Current Biology",
+    "date": "2017-10-13",
+    "first_author": "Melinda A. Yang",
+    "doi_link": "https://doi.org/10.1016/j.cub.2017.09.030"
+  },
+  "10.1016/j.cub.2017.09.059": {
+    "title": "Genomic Analyses of Pre-European Conquest Human Remains from the Canary Islands Reveal Close Affinity to Modern North Africans",
+    "year": 2017,
+    "journal": "Current Biology",
+    "date": "2017-10-26",
+    "first_author": "Ricardo Rodríguez-Varela",
+    "doi_link": "https://doi.org/10.1016/j.cub.2017.09.059"
+  },
+  "10.1016/j.cub.2018.02.051": {
+    "title": "Population Turnover in Remote Oceania Shortly after Initial Settlement",
+    "year": 2018,
+    "journal": "Current Biology",
+    "date": "2018-02-28",
+    "first_author": "Mark Lipson",
+    "doi_link": "https://doi.org/10.1016/j.cub.2018.02.051"
+  },
+  "10.1016/j.cub.2018.06.053": {
+    "title": "Genomic and Strontium Isotope Variation Reveal Immigration Patterns in a Viking Age Town",
+    "year": 2018,
+    "journal": "Current Biology",
+    "date": "2018-08-23",
+    "first_author": "Maja Krzewińska",
+    "doi_link": "https://doi.org/10.1016/j.cub.2018.06.053"
+  },
+  "10.1016/j.cub.2020.04.002": {
+    "title": "Origin and Health Status of First-Generation Africans from Early Colonial Mexico",
+    "year": 2020,
+    "journal": "Current Biology",
+    "date": "2020-04-30",
+    "first_author": "Rodrigo Barquera",
+    "doi_link": "https://doi.org/10.1016/j.cub.2020.04.002"
+  },
+  "10.1016/j.cub.2020.08.033": {
+    "title": "Low Prevalence of Lactase Persistence in Bronze Age Europe Indicates Ongoing Strong Selection over the Last 3,000 Years",
+    "year": 2020,
+    "journal": "Current Biology",
+    "date": "2020-09-03",
+    "first_author": "Joachim Burger",
+    "doi_link": "https://doi.org/10.1016/j.cub.2020.08.033"
+  },
+  "10.1016/j.cub.2020.12.015": {
+    "title": "Heterogeneous Hunter-Gatherer and Steppe-Related Ancestries in Late Neolithic and Bell Beaker Genomes from Present-Day France",
+    "year": 2021,
+    "journal": "Current Biology",
+    "date": "2021-01-13",
+    "first_author": "Andaine Seguin-Orlando",
+    "doi_link": "https://doi.org/10.1016/j.cub.2020.12.015"
+  },
+  "10.1016/j.cub.2021.03.050": {
+    "title": "Variable kinship patterns in Neolithic Anatolia revealed by ancient genomes",
+    "year": 2021,
+    "journal": "Current Biology",
+    "date": "2021-04-15",
+    "first_author": "Reyhan Yaka",
+    "doi_link": "https://doi.org/10.1016/j.cub.2021.03.050"
+  },
+  "10.1016/j.cub.2021.03.078": {
+    "title": "Early Alpine occupation backdates westward human migration in Late Glacial Europe",
+    "year": 2021,
+    "journal": "Current Biology",
+    "date": "2021-04-21",
+    "first_author": "Eugenio Bortolini",
+    "doi_link": "https://doi.org/10.1016/j.cub.2021.03.078"
+  },
+  "10.1016/j.cub.2021.04.045": {
+    "title": "Genome of Peştera Muierii skull shows high diversity and low mutational load in pre-glacial Europe",
+    "year": 2021,
+    "journal": "Current Biology",
+    "date": "2021-05-18",
+    "first_author": "Emma Svensson",
+    "doi_link": "https://doi.org/10.1016/j.cub.2021.04.045"
+  },
+  "10.1038/jhg.2016.110": {
+    "title": "A partial nuclear genome of the Jomons who lived 3000 years ago in Fukushima, Japan",
+    "year": 2017,
+    "journal": "Journal of Human Genetics",
+    "date": "2016-09-01",
+    "first_author": "Hideaki Kanzawa-Kiriyama",
+    "doi_link": "https://doi.org/10.1038/jhg.2016.110"
+  },
+  "10.1038/nature04072": {
+    "title": "Initial sequence of the chimpanzee genome and comparison with the human genome",
+    "year": "2005",
+    "journal": "Nature",
+    "date": "2005-09-01",
+    "first_author": "Chimpanzee Sequencing and Analysis Consortium",
+    "doi_link": "https://doi.org/10.1038/nature04072"
+  },
+  "10.1038/nature08835": {
+    "title": "Ancient human genome sequence of an extinct Palaeo-Eskimo",
+    "year": 2010,
+    "journal": "Nature",
+    "date": "2010-02-09",
+    "first_author": "Morten Rasmussen",
+    "doi_link": "https://doi.org/10.1038/nature08835"
+  },
+  "10.1038/nature12736": {
+    "title": "Upper Palaeolithic Siberian genome reveals dual ancestry of Native Americans",
+    "year": 2014,
+    "journal": "Nature",
+    "date": "2013-11-19",
+    "first_author": "Maanasa Raghavan",
+    "doi_link": "https://doi.org/10.1038/nature12736"
+  },
+  "10.1038/nature12886": {
+    "title": "The complete genome sequence of a Neanderthal from the Altai Mountains",
+    "year": 2014,
+    "journal": "Nature",
+    "date": "2013-12-18",
+    "first_author": "Kay Prüfer",
+    "doi_link": "https://doi.org/10.1038/nature12886"
+  },
+  "10.1038/nature12960": {
+    "title": "Derived immune and ancestral pigmentation alleles in a 7,000-year-old Mesolithic European",
+    "year": 2014,
+    "journal": "Nature",
+    "date": "2014-01-24",
+    "first_author": "Iñigo Olalde",
+    "doi_link": "https://doi.org/10.1038/nature12960"
+  },
+  "10.1038/nature13025": {
+    "title": "The genome of a Late Pleistocene human from a Clovis burial site in western Montana",
+    "year": 2014,
+    "journal": "Nature",
+    "date": "2014-02-11",
+    "first_author": "Morten Rasmussen",
+    "doi_link": "https://doi.org/10.1038/nature13025"
+  },
+  "10.1038/nature13673": {
+    "title": "Ancient human genomes suggest three ancestral populations for present-day Europeans",
+    "year": 2014,
+    "journal": "Nature",
+    "date": "2014-09-17",
+    "first_author": "Iosif Lazaridis",
+    "doi_link": "https://doi.org/10.1038/nature13673"
+  },
+  "10.1038/nature13810": {
+    "title": "Genome sequence of a 45,000-year-old modern human from western Siberia",
+    "year": 2014,
+    "journal": "Nature",
+    "date": "2014-10-21",
+    "first_author": "Qiaomei Fu",
+    "doi_link": "https://doi.org/10.1038/nature13810"
+  },
+  "10.1038/nature14507": {
+    "title": "Population genomics of Bronze Age Eurasia",
+    "year": 2015,
+    "journal": "Nature",
+    "date": "2015-06-09",
+    "first_author": "Morten E. Allentoft",
+    "doi_link": "https://doi.org/10.1038/nature14507"
+  },
+  "10.1038/nature14558": {
+    "title": "An early modern human from Romania with a recent Neanderthal ancestor",
+    "year": 2015,
+    "journal": "Nature",
+    "date": "2015-06-22",
+    "first_author": "Qiaomei Fu",
+    "doi_link": "https://doi.org/10.1038/nature14558"
+  },
+  "10.1038/nature14625": {
+    "title": "The ancestry and affiliations of Kennewick Man",
+    "year": 2015,
+    "journal": "Nature",
+    "date": "2015-06-18",
+    "first_author": "Morten Rasmussen",
+    "doi_link": "https://doi.org/10.1038/nature14625"
+  },
+  "10.1038/nature15393": {
+    "title": "A global reference for human genetic variation",
+    "year": 2015,
+    "journal": "Nature",
+    "date": "2015-09-29",
+    "first_author": " ",
+    "doi_link": "https://doi.org/10.1038/nature15393"
+  },
+  "10.1038/nature16152": {
+    "title": "Genome-wide patterns of selection in 230 ancient Eurasians",
+    "year": 2015,
+    "journal": "Nature",
+    "date": "2015-11-23",
+    "first_author": "Iain Mathieson",
+    "doi_link": "https://doi.org/10.1038/nature16152"
+  },
+  "10.1038/nature17993": {
+    "title": "The genetic history of Ice Age Europe",
+    "year": 2016,
+    "journal": "Nature",
+    "date": "2016-04-29",
+    "first_author": "Qiaomei Fu",
+    "doi_link": "https://doi.org/10.1038/nature17993"
+  },
+  "10.1038/nature19310": {
+    "title": "Genomic insights into the origin of farming in the ancient Near East",
+    "year": 2016,
+    "journal": "Nature",
+    "date": "2016-07-26",
+    "first_author": "Iosif Lazaridis",
+    "doi_link": "https://doi.org/10.1038/nature19310"
+  },
+  "10.1038/nature19844": {
+    "title": "Genomic insights into the peopling of the Southwest Pacific",
+    "year": 2016,
+    "journal": "Nature",
+    "date": "2016-09-30",
+    "first_author": "Pontus Skoglund",
+    "doi_link": "https://doi.org/10.1038/nature19844"
+  },
+  "10.1038/nature23310": {
+    "title": "Genetic origins of the Minoans and Mycenaeans",
+    "year": 2017,
+    "journal": "Nature",
+    "date": "2017-08-01",
+    "first_author": "Iosif Lazaridis",
+    "doi_link": "https://doi.org/10.1038/nature23310"
+  },
+  "10.1038/nature24476": {
+    "title": "Parallel palaeogenomic transects reveal complex genetic history of early European farmers",
+    "year": 2017,
+    "journal": "Nature",
+    "date": "2017-11-07",
+    "first_author": "Mark Lipson",
+    "doi_link": "https://doi.org/10.1038/nature24476"
+  },
+  "10.1038/nature25173": {
+    "title": "Terminal Pleistocene Alaskan genome reveals first founding population of Native Americans",
+    "year": 2018,
+    "journal": "Nature",
+    "date": "2018-01-02",
+    "first_author": "J. Víctor Moreno-Mayar",
+    "doi_link": "https://doi.org/10.1038/nature25173"
+  },
+  "10.1038/nature25738": {
+    "title": "The Beaker phenomenon and the genomic transformation of northwest Europe",
+    "year": 2018,
+    "journal": "Nature",
+    "date": "2018-02-21",
+    "first_author": "Iñigo Olalde",
+    "doi_link": "https://doi.org/10.1038/nature25738"
+  },
+  "10.1038/nature25778": {
+    "title": "The genomic history of southeastern Europe",
+    "year": 2018,
+    "journal": "Nature",
+    "date": "2018-02-21",
+    "first_author": "Iain Mathieson",
+    "doi_link": "https://doi.org/10.1038/nature25778"
+  },
+  "10.1038/nature26151": {
+    "title": "Reconstructing the genetic history of late Neanderthals",
+    "year": 2018,
+    "journal": "Nature",
+    "date": "2018-03-20",
+    "first_author": "Mateja Hajdinjak",
+    "doi_link": "https://doi.org/10.1038/nature26151"
+  },
+  "10.1038/ncomms10326": {
+    "title": "Genomic signals of migration and continuity in Britain before the Anglo-Saxons",
+    "year": 2016,
+    "journal": "Nature Communications",
+    "date": "2016-01-19",
+    "first_author": "Rui Martiniano",
+    "doi_link": "https://doi.org/10.1038/ncomms10326"
+  },
+  "10.1038/ncomms10408": {
+    "title": "Iron Age and Anglo-Saxon genomes from East England reveal British migration history",
+    "year": 2016,
+    "journal": "Nature Communications",
+    "date": "2016-01-19",
+    "first_author": "Stephan Schiffels",
+    "doi_link": "https://doi.org/10.1038/ncomms10408"
+  },
+  "10.1038/ncomms14115": {
+    "title": "Archaeogenomic evidence reveals prehistoric matrilineal dynasty",
+    "year": 2017,
+    "journal": "Nature Communications",
+    "date": "2017-02-21",
+    "first_author": "Douglas J. Kennett",
+    "doi_link": "https://doi.org/10.1038/ncomms14115"
+  },
+  "10.1038/ncomms14615": {
+    "title": "Ancestry and demography and descendants of Iron Age nomads of the Eurasian Steppe",
+    "year": 2017,
+    "journal": "Nature Communications",
+    "date": "2017-03-03",
+    "first_author": "Martina Unterländer",
+    "doi_link": "https://doi.org/10.1038/ncomms14615"
+  },
+  "10.1038/ncomms1701": {
+    "title": "New insights into the Tyrolean Iceman's origin and phenotype as inferred by whole-genome sequencing",
+    "year": 2012,
+    "journal": "Nature Communications",
+    "date": "2012-02-28",
+    "first_author": "Andreas Keller",
+    "doi_link": "https://doi.org/10.1038/ncomms1701"
+  },
+  "10.1038/ncomms2140": {
+    "title": "The genetic prehistory of southern Africa",
+    "year": 2012,
+    "journal": "Nature Communications",
+    "date": "2012-10-16",
+    "first_author": "Joseph K. Pickrell",
+    "doi_link": "https://doi.org/10.1038/ncomms2140"
+  },
+  "10.1038/ncomms6257": {
+    "title": "Genome flux and stasis in a five millennium transect of European prehistory",
+    "year": 2014,
+    "journal": "Nature Communications",
+    "date": "2014-10-21",
+    "first_author": "Cristina Gamba",
+    "doi_link": "https://doi.org/10.1038/ncomms6257"
+  },
+  "10.1038/ncomms9912": {
+    "title": "Upper Palaeolithic genomes reveal deep roots of modern Eurasians",
+    "year": 2015,
+    "journal": "Nature Communications",
+    "date": "2015-11-16",
+    "first_author": "Eppie R. Jones",
+    "doi_link": "https://doi.org/10.1038/ncomms9912"
+  },
+  "10.1038/ng.3621": {
+    "title": "Genomic analysis of Andamanese provides insights into ancient human migration into Asia and adaptation",
+    "year": 2016,
+    "journal": "Nature Genetics",
+    "date": "2016-07-25",
+    "first_author": "Mayukh Mondal",
+    "doi_link": "https://doi.org/10.1038/ng.3621"
+  },
+  "10.1038/s41467-018-05649-9": {
+    "title": "Ancient DNA from Chalcolithic Israel reveals the role of population mixture in cultural transformation",
+    "year": 2018,
+    "journal": "Nature Communications",
+    "date": "2018-08-14",
+    "first_author": "Éadaoin Harney",
+    "doi_link": "https://doi.org/10.1038/s41467-018-05649-9"
+  },
+  "10.1038/s41467-018-06024-4": {
+    "title": "Understanding 6th-century barbarian social organization and migration through paleogenomics",
+    "year": 2018,
+    "journal": "Nature Communications",
+    "date": "2018-08-28",
+    "first_author": "Carlos Eduardo G. Amorim",
+    "doi_link": "https://doi.org/10.1038/s41467-018-06024-4"
+  },
+  "10.1038/s41467-020-14523-6": {
+    "title": "Genetic history from the Middle Neolithic to present on the Mediterranean island of Sardinia",
+    "year": 2020,
+    "journal": "Nature Communications",
+    "date": "2020-02-24",
+    "first_author": "Joseph H. Marcus",
+    "doi_link": "https://doi.org/10.1038/s41467-020-14523-6"
+  },
+  "10.1038/s41467-023-44328-2": {
+    "title": "Genomic portrait and relatedness patterns of the Iron Age Log Coffin culture in northwestern Thailand",
+    "year": 2023,
+    "journal": "Nature Communications",
+    "date": "2023-12-22",
+    "first_author": "Selina Carlhoff",
+    "doi_link": "https://doi.org/10.1038/s41467-023-44328-2"
+  },
+  "10.1038/s41559-018-0498-2": {
+    "title": "Language continuity despite population replacement in Remote Oceania",
+    "year": 2018,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2018-02-26",
+    "first_author": "Cosimo Posth",
+    "doi_link": "https://doi.org/10.1038/s41559-018-0498-2"
+  },
+  "10.1038/s41559-019-0871-9": {
+    "title": "Ancient genomes indicate population replacement in Early Neolithic Britain",
+    "year": 2019,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2019-04-15",
+    "first_author": "Selina Brace",
+    "doi_link": "https://doi.org/10.1038/s41559-019-0871-9"
+  },
+  "10.1038/s41559-019-0878-2": {
+    "title": "The genetic history of admixture across inner Eurasia",
+    "year": 2019,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2019-04-29",
+    "first_author": "Choongwon Jeong",
+    "doi_link": "https://doi.org/10.1038/s41559-019-0878-2"
+  },
+  "10.1038/s41559-020-1102-0": {
+    "title": "The spread of steppe and Iranian-related ancestry in the islands of the western Mediterranean",
+    "year": 2020,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2020-02-24",
+    "first_author": "Daniel M. Fernandes",
+    "doi_link": "https://doi.org/10.1038/s41559-020-1102-0"
+  },
+  "10.1038/s41586-018-0094-2": {
+    "title": "137 ancient human genomes from across the Eurasian steppes",
+    "year": 2018,
+    "journal": "Nature",
+    "date": "2018-05-08",
+    "first_author": "Peter de Barros Damgaard",
+    "doi_link": "https://doi.org/10.1038/s41586-018-0094-2"
+  },
+  "10.1038/s41586-018-0455-x": {
+    "title": "The genome of the offspring of a Neanderthal mother and a Denisovan father",
+    "year": 2018,
+    "journal": "Nature",
+    "date": "2018-08-21",
+    "first_author": "Viviane Slon",
+    "doi_link": "https://doi.org/10.1038/s41586-018-0455-x"
+  },
+  "10.1038/s41586-019-1251-y": {
+    "title": "Palaeo-Eskimo genetic ancestry and the peopling of Chukotka and North America",
+    "year": 2019,
+    "journal": "Nature",
+    "date": "2019-06-05",
+    "first_author": "Pavel Flegontov",
+    "doi_link": "https://doi.org/10.1038/s41586-019-1251-y"
+  },
+  "10.1038/s41586-020-03053-2": {
+    "title": "A genetic history of the pre-contact Caribbean",
+    "year": 2021,
+    "journal": "Nature",
+    "date": "2020-12-23",
+    "first_author": "Daniel M. Fernandes",
+    "doi_link": "https://doi.org/10.1038/s41586-020-03053-2"
+  },
+  "10.1038/s41586-020-1929-1": {
+    "title": "Ancient West African foragers in the context of African population history",
+    "year": 2020,
+    "journal": "Nature",
+    "date": "2020-01-22",
+    "first_author": "Mark Lipson",
+    "doi_link": "https://doi.org/10.1038/s41586-020-1929-1"
+  },
+  "10.1038/s41586-020-2688-8": {
+    "title": "Population genomics of the Viking world",
+    "year": 2020,
+    "journal": "Nature",
+    "date": "2020-09-17",
+    "first_author": "Ashot Margaryan",
+    "doi_link": "https://doi.org/10.1038/s41586-020-2688-8"
+  },
+  "10.1038/s41586-021-03336-2": {
+    "title": "Genomic insights into the formation of human populations in East Asia",
+    "year": 2021,
+    "journal": "Nature",
+    "date": "2021-02-22",
+    "first_author": "Chuan-Chao Wang",
+    "doi_link": "https://doi.org/10.1038/s41586-021-03336-2"
+  },
+  "10.1038/s41586-021-03823-6": {
+    "title": "Genome of a middle Holocene hunter-gatherer from Wallacea",
+    "year": 2021,
+    "journal": "Nature",
+    "date": "2021-08-25",
+    "first_author": "Selina Carlhoff",
+    "doi_link": "https://doi.org/10.1038/s41586-021-03823-6"
+  },
+  "10.1038/s41586-022-05247-2": {
+    "title": "The Anglo-Saxon migration and the formation of the early English gene pool",
+    "year": 2022,
+    "journal": "Nature",
+    "date": "2022-09-21",
+    "first_author": "Joscha Gretzinger",
+    "doi_link": "https://doi.org/10.1038/s41586-022-05247-2"
+  },
+  "10.1038/s41586-023-06334-8": {
+    "title": "Early contact between late farming and pastoralist societies in southeastern Europe",
+    "year": 2023,
+    "journal": "Nature",
+    "date": "2023-07-19",
+    "first_author": "Sandra Penske",
+    "doi_link": "https://doi.org/10.1038/s41586-023-06334-8"
+  },
+  "10.1038/s41598-018-33067-w": {
+    "title": "A genomic Neolithic time transect of hunter-farmer admixture in central Poland",
+    "year": 2018,
+    "journal": "Scientific Reports",
+    "date": "2018-10-01",
+    "first_author": "D. M. Fernandes",
+    "doi_link": "https://doi.org/10.1038/s41598-018-33067-w"
+  },
+  "10.1038/s41598-021-89090-x": {
+    "title": "Ancient genomes provide insights into family structure and the heredity of social status in the early Bronze Age of southeastern Europe",
+    "year": 2021,
+    "journal": "Scientific Reports",
+    "date": "2021-05-12",
+    "first_author": "A. Žegarac",
+    "doi_link": "https://doi.org/10.1038/s41598-021-89090-x"
+  },
+  "10.1038/s42003-020-01372-8": {
+    "title": "Ancient DNA reveals monozygotic newborn twins from the Upper Palaeolithic",
+    "year": 2020,
+    "journal": "Communications Biology",
+    "date": "2020-11-06",
+    "first_author": "Maria Teschler-Nicola",
+    "doi_link": "https://doi.org/10.1038/s42003-020-01372-8"
+  },
+  "10.1073/pnas.1509851112": {
+    "title": "Ancient genomes link early farmers from Atapuerca in Spain to modern-day Basques",
+    "year": 2015,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2015-09-09",
+    "first_author": "Torsten Günther",
+    "doi_link": "https://doi.org/10.1073/pnas.1509851112"
+  },
+  "10.1073/pnas.1518445113": {
+    "title": "Neolithic and Bronze Age migration to Ireland and establishment of the insular Atlantic genome",
+    "year": 2016,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2015-12-29",
+    "first_author": "Lara M. Cassidy",
+    "doi_link": "https://doi.org/10.1073/pnas.1518445113"
+  },
+  "10.1073/pnas.1520844113": {
+    "title": "Long-term genetic stability and a high-altitude East Asian origin for the peoples of the high valleys of the Himalayan arc",
+    "year": 2016,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2016-06-21",
+    "first_author": "Choongwon Jeong",
+    "doi_link": "https://doi.org/10.1073/pnas.1520844113"
+  },
+  "10.1073/pnas.1523951113": {
+    "title": "Early farmers from across Europe directly descended from Neolithic Aegeans",
+    "year": 2016,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2016-06-06",
+    "first_author": "Zuzana Hofmanová",
+    "doi_link": "https://doi.org/10.1073/pnas.1523951113"
+  },
+  "10.1073/pnas.1620410114": {
+    "title": "Ancient individuals from the North American Northwest Coast reveal 10,000 years of regional genetic continuity",
+    "year": 2017,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2017-04-04",
+    "first_author": "John Lindo",
+    "doi_link": "https://doi.org/10.1073/pnas.1620410114"
+  },
+  "10.1073/pnas.1715688115": {
+    "title": "Genomic insights into the origin and diversification of late maritime hunter-gatherers from the Chilean Patagonia",
+    "year": 2018,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2018-04-09",
+    "first_author": "Constanza de la Fuente",
+    "doi_link": "https://doi.org/10.1073/pnas.1715688115"
+  },
+  "10.1073/pnas.1716839115": {
+    "title": "Origins and genetic legacies of the Caribbean Taino",
+    "year": 2018,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2018-02-20",
+    "first_author": "Hannes Schroeder",
+    "doi_link": "https://doi.org/10.1073/pnas.1716839115"
+  },
+  "10.1073/pnas.1717762115": {
+    "title": "Four millennia of Iberian biomolecular prehistory illustrate the impact of prehistoric migrations at the far end of Eurasia",
+    "year": 2018,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2018-03-12",
+    "first_author": "Cristina Valdiosera",
+    "doi_link": "https://doi.org/10.1073/pnas.1717762115"
+  },
+  "10.1073/pnas.1719880115": {
+    "title": "Population genomic analysis of elongated skulls reveals extensive female-biased immigration in Early Medieval Bavaria",
+    "year": 2018,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2018-03-12",
+    "first_author": "Krishna R. Veeramah",
+    "doi_link": "https://doi.org/10.1073/pnas.1719880115"
+  },
+  "10.1073/pnas.1800851115": {
+    "title": "Ancient genomes from North Africa evidence prehistoric migrations to the Maghreb from both the Levant and Europe",
+    "year": 2018,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2018-06-12",
+    "first_author": "Rosa Fregel",
+    "doi_link": "https://doi.org/10.1073/pnas.1800851115"
+  },
+  "10.1073/pnas.2004944117": {
+    "title": "A high-coverage Neandertal genome from Chagyrskaya Cave",
+    "year": 2020,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2020-06-16",
+    "first_author": "Fabrizio Mafessoni",
+    "doi_link": "https://doi.org/10.1073/pnas.2004944117"
+  },
+  "10.1073/pnas.2022112118": {
+    "title": "Ancient DNA from Guam and the peopling of the Pacific",
+    "year": 2021,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2020-12-23",
+    "first_author": "Irina Pugach",
+    "doi_link": "https://doi.org/10.1073/pnas.2022112118"
+  },
+  "10.1073/pnas.2026132118": {
+    "title": "Multiple migrations to the Philippines during the last 50,000 years",
+    "year": 2021,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2021-03-22",
+    "first_author": "Maximilian Larena",
+    "doi_link": "https://doi.org/10.1073/pnas.2026132118"
+  },
+  "10.1080/00758914.2017.1368204": {
+    "title": "A Late Bronze Age II clay coffin from Tel Shaddud in the Central Jezreel Valley, Israel: context and historical implications",
+    "year": 2017,
+    "journal": "Levant",
+    "date": "2017-10-17",
+    "first_author": "Edwin C. M. van den Brink",
+    "doi_link": "https://doi.org/10.1080/00758914.2017.1368204"
+  },
+  "10.1093/molbev/msv181": {
+    "title": "A Common Genetic Origin for Early Farmers from Mediterranean Cardial and Central European LBK Cultures",
+    "year": 2015,
+    "journal": "Molecular Biology and Evolution",
+    "date": "2015-09-03",
+    "first_author": "Iñigo Olalde",
+    "doi_link": "https://doi.org/10.1093/molbev/msv181"
+  },
+  "10.1093/molbev/msz267": {
+    "title": "Ancient DNA Reconstructs the Genetic Legacies of Precontact Puerto Rico Communities",
+    "year": 2020,
+    "journal": "Molecular Biology and Evolution",
+    "date": "2019-11-08",
+    "first_author": "Maria A Nieves-Colón",
+    "doi_link": "https://doi.org/10.1093/molbev/msz267"
+  },
+  "10.1101/gr.267534.120": {
+    "title": "A minimally destructive protocol for DNA extraction from ancient teeth",
+    "year": 2021,
+    "journal": "Genome Research",
+    "date": "2021-02-16",
+    "first_author": "Éadaoin Harney",
+    "doi_link": "https://doi.org/10.1101/gr.267534.120"
+  },
+  "10.1126/sciadv.aat4457": {
+    "title": "Ancient genomes suggest the eastern Pontic-Caspian steppe as the source of western Iron Age nomads",
+    "year": 2018,
+    "journal": "Science Advances",
+    "date": "2018-10-04",
+    "first_author": "Maja Krzewińska",
+    "doi_link": "https://doi.org/10.1126/sciadv.aat4457"
+  },
+  "10.1126/sciadv.aau4921": {
+    "title": "The genetic prehistory of the Andean highlands 7000 years BP though European contact",
+    "year": 2018,
+    "journal": "Science Advances",
+    "date": "2018-11-08",
+    "first_author": "John Lindo",
+    "doi_link": "https://doi.org/10.1126/sciadv.aau4921"
+  },
+  "10.1126/sciadv.aaz0183": {
+    "title": "Ancient genomes reveal complex patterns of population movement, interaction, and replacement in sub-Saharan Africa",
+    "year": 2020,
+    "journal": "Science Advances",
+    "date": "2020-06-12",
+    "first_author": "Ke Wang",
+    "doi_link": "https://doi.org/10.1126/sciadv.aaz0183"
+  },
+  "10.1126/sciadv.abc4587": {
+    "title": "Human population dynamics and\n            <i>Yersinia pestis</i>\n            in ancient northeast Asia",
+    "year": 2021,
+    "journal": "Science Advances",
+    "date": "2021-01-06",
+    "first_author": "Gülşah Merve Kılınç",
+    "doi_link": "https://doi.org/10.1126/sciadv.abc4587"
+  },
+  "10.1126/sciadv.abd6535": {
+    "title": "Genetic ancestry changes in Stone to Bronze Age transition in the East European plain",
+    "year": 2021,
+    "journal": "Science Advances",
+    "date": "2021-01-20",
+    "first_author": "Lehti Saag",
+    "doi_link": "https://doi.org/10.1126/sciadv.abd6535"
+  },
+  "10.1126/sciadv.abe4414": {
+    "title": "Ancient genomic time transect from the Central Asian Steppe unravels the history of the Scythians",
+    "year": 2021,
+    "journal": "Science Advances",
+    "date": "2021-03-26",
+    "first_author": "Guido Alberto Gnecchi-Ruscone",
+    "doi_link": "https://doi.org/10.1126/sciadv.abe4414"
+  },
+  "10.1126/sciadv.abi6941": {
+    "title": "Dynamic changes in genomic and social structures in third millennium BCE central Europe",
+    "year": 2021,
+    "journal": "Science Advances",
+    "date": "2021-08-25",
+    "first_author": "Luka Papac",
+    "doi_link": "https://doi.org/10.1126/sciadv.abi6941"
+  },
+  "10.1126/science.1224344": {
+    "title": "A High-Coverage Genome Sequence from an Archaic Denisovan Individual",
+    "year": 2012,
+    "journal": "Science",
+    "date": "2012-09-01",
+    "first_author": "Matthias Meyer",
+    "doi_link": "https://doi.org/10.1126/science.1224344"
+  },
+  "10.1126/science.1253448": {
+    "title": "Genomic Diversity and Admixture Differs for Stone-Age Scandinavian Foragers and Farmers",
+    "year": 2014,
+    "journal": "Science",
+    "date": "2014-04-25",
+    "first_author": "Pontus Skoglund",
+    "doi_link": "https://doi.org/10.1126/science.1253448"
+  },
+  "10.1126/science.1255832": {
+    "title": "The genetic prehistory of the New World Arctic",
+    "year": 2014,
+    "journal": "Science",
+    "date": "2014-08-28",
+    "first_author": "Maanasa Raghavan",
+    "doi_link": "https://doi.org/10.1126/science.1255832"
+  },
+  "10.1126/science.aaa0114": {
+    "title": "Genomic structure in Europeans dating back at least 36,200 years",
+    "year": 2014,
+    "journal": "Science",
+    "date": "2014-11-07",
+    "first_author": "Andaine Seguin-Orlando",
+    "doi_link": "https://doi.org/10.1126/science.aaa0114"
+  },
+  "10.1126/science.aab3884": {
+    "title": "Genomic evidence for the Pleistocene and recent population history of Native Americans",
+    "year": 2015,
+    "journal": "Science",
+    "date": "2015-07-22",
+    "first_author": "Maanasa Raghavan",
+    "doi_link": "https://doi.org/10.1126/science.aab3884"
+  },
+  "10.1126/science.aad2879": {
+    "title": "Ancient Ethiopian genome reveals extensive Eurasian admixture in Eastern Africa",
+    "year": 2015,
+    "journal": "Science",
+    "date": "2015-10-09",
+    "first_author": "M. Gallego Llorente",
+    "doi_link": "https://doi.org/10.1126/science.aad2879"
+  },
+  "10.1126/science.aae0344": {
+    "title": "Long-read sequence assembly of the gorilla genome",
+    "year": 2016,
+    "journal": "Science",
+    "date": "2016-03-31",
+    "first_author": "David Gordon",
+    "doi_link": "https://doi.org/10.1126/science.aae0344"
+  },
+  "10.1126/science.aaf7943": {
+    "title": "Early Neolithic genomes from the eastern Fertile Crescent",
+    "year": 2016,
+    "journal": "Science",
+    "date": "2016-07-15",
+    "first_author": "Farnaz Broushaki",
+    "doi_link": "https://doi.org/10.1126/science.aaf7943"
+  },
+  "10.1126/science.aao1807": {
+    "title": "Ancient genomes show social and reproductive behavior of early Upper Paleolithic foragers",
+    "year": 2017,
+    "journal": "Science",
+    "date": "2017-10-06",
+    "first_author": "Martin Sikora",
+    "doi_link": "https://doi.org/10.1126/science.aao1807"
+  },
+  "10.1126/science.aao1887": {
+    "title": "A high-coverage Neandertal genome from Vindija Cave in Croatia",
+    "year": 2017,
+    "journal": "Science",
+    "date": "2017-10-06",
+    "first_author": "Kay Prüfer",
+    "doi_link": "https://doi.org/10.1126/science.aao1887"
+  },
+  "10.1126/science.aao6266": {
+    "title": "Southern African ancient genomes estimate modern human divergence to 350,000 to 260,000 years ago",
+    "year": 2017,
+    "journal": "Science",
+    "date": "2017-09-29",
+    "first_author": "Carina M. Schlebusch",
+    "doi_link": "https://doi.org/10.1126/science.aao6266"
+  },
+  "10.1126/science.aar6851": {
+    "title": "Ancient human parallel lineages within North America contributed to a coastal expansion",
+    "year": 2018,
+    "journal": "Science",
+    "date": "2018-06-04",
+    "first_author": "C. L. Scheib",
+    "doi_link": "https://doi.org/10.1126/science.aar6851"
+  },
+  "10.1126/science.aar7711": {
+    "title": "The first horse herders and the impact of early Bronze Age steppe expansions into Asia",
+    "year": 2018,
+    "journal": "Science",
+    "date": "2018-05-09",
+    "first_author": "Peter de Barros Damgaard",
+    "doi_link": "https://doi.org/10.1126/science.aar7711"
+  },
+  "10.1126/science.aat3188": {
+    "title": "Ancient genomes document multiple waves of migration in Southeast Asian prehistory",
+    "year": 2018,
+    "journal": "Science",
+    "date": "2018-05-17",
+    "first_author": "Mark Lipson",
+    "doi_link": "https://doi.org/10.1126/science.aat3188"
+  },
+  "10.1126/science.aat3628": {
+    "title": "The prehistoric peopling of Southeast Asia",
+    "year": 2018,
+    "journal": "Science",
+    "date": "2018-07-05",
+    "first_author": "Hugh McColl",
+    "doi_link": "https://doi.org/10.1126/science.aat3628"
+  },
+  "10.1126/science.aat7487": {
+    "title": "The formation of human populations in South and Central Asia",
+    "year": 2019,
+    "journal": "Science",
+    "date": "2019-09-05",
+    "first_author": "Vagheesh M. Narasimhan",
+    "doi_link": "https://doi.org/10.1126/science.aat7487"
+  },
+  "10.1126/science.aav2621": {
+    "title": "Early human dispersals within the Americas",
+    "year": 2018,
+    "journal": "Science",
+    "date": "2018-11-08",
+    "first_author": "J. Víctor Moreno-Mayar",
+    "doi_link": "https://doi.org/10.1126/science.aav2621"
+  },
+  "10.1126/science.aav4040": {
+    "title": "The genomic history of the Iberian Peninsula over the past 8000 years",
+    "year": 2019,
+    "journal": "Science",
+    "date": "2019-03-14",
+    "first_author": "Iñigo Olalde",
+    "doi_link": "https://doi.org/10.1126/science.aav4040"
+  },
+  "10.1126/science.aaw6275": {
+    "title": "Ancient DNA reveals a multistep spread of the first herders into sub-Saharan Africa",
+    "year": 2019,
+    "journal": "Science",
+    "date": "2019-05-30",
+    "first_author": "Mary E. Prendergast",
+    "doi_link": "https://doi.org/10.1126/science.aaw6275"
+  },
+  "10.1126/science.aay5012": {
+    "title": "Insights into human genetic variation and population history from 929 diverse genomes",
+    "year": 2020,
+    "journal": "Science",
+    "date": "2020-03-19",
+    "first_author": "Anders Bergström",
+    "doi_link": "https://doi.org/10.1126/science.aay5012"
+  },
+  "10.1126/science.aba8697": {
+    "title": "Genomic insights into the early peopling of the Caribbean",
+    "year": 2020,
+    "journal": "Science",
+    "date": "2020-06-04",
+    "first_author": "Kathrin Nägele",
+    "doi_link": "https://doi.org/10.1126/science.aba8697"
+  },
+  "10.1126/science.abc1166": {
+    "title": "Denisovan ancestry and population history of early East Asians",
+    "year": 2020,
+    "journal": "Science",
+    "date": "2020-10-29",
+    "first_author": "Diyendo Massilani",
+    "doi_link": "https://doi.org/10.1126/science.abc1166"
+  },
+  "10.1371/journal.pbio.1001091": {
+    "title": "Modernizing Reference Genome Assemblies",
+    "year": 2011,
+    "journal": "PLoS Biology",
+    "date": "2011-07-05",
+    "first_author": "Deanna M. Church",
+    "doi_link": "https://doi.org/10.1371/journal.pbio.1001091"
+  },
+  "10.1371/journal.pbio.2003703": {
+    "title": "Population genomics of Mesolithic Scandinavia: Investigating early postglacial migration routes and high-latitude adaptation",
+    "year": 2018,
+    "journal": "PLOS Biology",
+    "date": "2018-01-09",
+    "first_author": "Torsten Günther",
+    "doi_link": "https://doi.org/10.1371/journal.pbio.2003703"
+  },
+  "10.1371/journal.pgen.1006852": {
+    "title": "The population genomics of archaeological transition in west Iberia: Investigation of ancient substructure using imputation and haplotype-based methods",
+    "year": 2017,
+    "journal": "PLOS Genetics",
+    "date": "2017-07-27",
+    "first_author": "Rui Martiniano",
+    "doi_link": "https://doi.org/10.1371/journal.pgen.1006852"
+  },
+  "10.1371/journal.pone.0244872": {
+    "title": "Genomic Steppe ancestry in skeletons from the Neolithic Single Grave Culture in Denmark",
+    "year": 2021,
+    "journal": "PLOS ONE",
+    "date": "2021-01-14",
+    "first_author": "Anne Friis-Holm Egfjord",
+    "doi_link": "https://doi.org/10.1371/journal.pone.0244872"
+  },
+  "10.1371/journal.pone.0247332": {
+    "title": "Genome-wide analysis of nearly all the victims of a 6200 year old massacre",
+    "year": 2021,
+    "journal": "PLOS ONE",
+    "date": "2021-03-10",
+    "first_author": "Mario Novak",
+    "doi_link": "https://doi.org/10.1371/journal.pone.0247332"
+  },
+  "10.1534/genetics.112.145037": {
+    "title": "Ancient Admixture in Human History",
+    "year": 2012,
+    "journal": "Genetics",
+    "date": "2012-09-08",
+    "first_author": "Nick Patterson",
+    "doi_link": "https://doi.org/10.1534/genetics.112.145037"
+  },
+  "10.1016/j.cub.2022.11.036": {
+    "title": "Genetic admixture and language shift in the medieval Volga-Oka interfluve",
+    "year": 2023,
+    "journal": "Current Biology",
+    "date": "2022-12-12",
+    "first_author": "Sanni Peltola",
+    "doi_link": "https://doi.org/10.1016/j.cub.2022.11.036"
+  },
+  "10.1038/s41598-021-94932-9": {
+    "title": "Reconstructing genetic histories and social organisation in Neolithic and Bronze Age Croatia",
+    "year": 2021,
+    "journal": "Scientific Reports",
+    "date": "2021-08-18",
+    "first_author": "Suzanne Freilich",
+    "doi_link": "https://doi.org/10.1038/s41598-021-94932-9"
+  },
+  "10.1007/s12520-024-02036-y": {
+    "title": "Ancient genomes provide insights into the genetic history in the historical era of southwest China",
+    "year": 2024,
+    "journal": "Archaeological and Anthropological Sciences",
+    "date": "2024-07-17",
+    "first_author": "Fan Zhang",
+    "doi_link": "https://doi.org/10.1007/s12520-024-02036-y"
+  },
+  "10.1016/j.ajhg.2019.03.015": {
+    "title": "A Transient Pulse of Genetic Admixture from the Crusaders in the Near East Identified from Ancient Genome Sequences",
+    "year": 2019,
+    "journal": "The American Journal of Human Genetics",
+    "date": "2019-04-18",
+    "first_author": "Marc Haber",
+    "doi_link": "https://doi.org/10.1016/j.ajhg.2019.03.015"
+  },
+  "10.1016/j.ajhg.2023.08.001": {
+    "title": "The ancestry and geographical origins of St Helena’s liberated Africans",
+    "year": 2023,
+    "journal": "The American Journal of Human Genetics",
+    "date": "2023-09-07",
+    "first_author": "Marcela Sandoval-Velasco",
+    "doi_link": "https://doi.org/10.1016/j.ajhg.2023.08.001"
+  },
+  "10.1016/j.cell.2018.10.027": {
+    "title": "Reconstructing the Deep Population History of Central and South America",
+    "year": 2018,
+    "journal": "Cell",
+    "date": "2018-11-08",
+    "first_author": "Cosimo Posth",
+    "doi_link": "https://doi.org/10.1016/j.cell.2018.10.027"
+  },
+  "10.1016/j.cell.2019.02.035": {
+    "title": "Multiple Deeply Divergent Denisovan Ancestries in Papuans",
+    "year": 2019,
+    "journal": "Cell",
+    "date": "2019-04-11",
+    "first_author": "Guy S. Jacobs",
+    "doi_link": "https://doi.org/10.1016/j.cell.2019.02.035"
+  },
+  "10.1016/j.cell.2019.08.048": {
+    "title": "An Ancient Harappan Genome Lacks Ancestry from Steppe Pastoralists or Iranian Farmers",
+    "year": 2019,
+    "journal": "Cell",
+    "date": "2019-09-05",
+    "first_author": "Vasant Shinde",
+    "doi_link": "https://doi.org/10.1016/j.cell.2019.08.048"
+  },
+  "10.1016/j.cell.2020.04.015": {
+    "title": "A Paleogenomic Reconstruction of the Deep Population History of the Andes",
+    "year": 2020,
+    "journal": "Cell",
+    "date": "2020-05-07",
+    "first_author": "Nathan Nakatsuka",
+    "doi_link": "https://doi.org/10.1016/j.cell.2020.04.015"
+  },
+  "10.1016/j.cell.2020.04.024": {
+    "title": "The Genomic History of the Bronze Age Southern Levant",
+    "year": 2020,
+    "journal": "Cell",
+    "date": "2020-05-28",
+    "first_author": "Lily Agranat-Tamir",
+    "doi_link": "https://doi.org/10.1016/j.cell.2020.04.024"
+  },
+  "10.1016/j.cell.2020.04.037": {
+    "title": "Paleolithic to Bronze Age Siberians Reveal Connections with First Americans and across Eurasia",
+    "year": 2020,
+    "journal": "Cell",
+    "date": "2020-05-20",
+    "first_author": "He Yu",
+    "doi_link": "https://doi.org/10.1016/j.cell.2020.04.037"
+  },
+  "10.1016/j.cell.2020.04.044": {
+    "title": "Genomic History of Neolithic to Bronze Age Anatolia, Northern Levant, and Southern Caucasus",
+    "year": 2020,
+    "journal": "Cell",
+    "date": "2020-05-28",
+    "first_author": "Eirini Skourtanioti",
+    "doi_link": "https://doi.org/10.1016/j.cell.2020.04.044"
+  },
+  "10.1016/j.cell.2021.05.018": {
+    "title": "Human population history at the crossroads of East and Southeast Asia since 11,000 years ago",
+    "year": 2021,
+    "journal": "Cell",
+    "date": "2021-06-24",
+    "first_author": "Tianyi Wang",
+    "doi_link": "https://doi.org/10.1016/j.cell.2021.05.018"
+  },
+  "10.1016/j.cell.2022.04.008": {
+    "title": "The genomic origins of the world’s first farmers",
+    "year": 2022,
+    "journal": "Cell",
+    "date": "2022-05-12",
+    "first_author": "Nina Marchi",
+    "doi_link": "https://doi.org/10.1016/j.cell.2022.04.008"
+  },
+  "10.1016/j.cell.2022.08.004": {
+    "title": "High-coverage whole-genome sequencing of the expanded 1000 Genomes Project cohort including 602 trios",
+    "year": 2022,
+    "journal": "Cell",
+    "date": "2022-09-01",
+    "first_author": "Marta Byrska-Bishop",
+    "doi_link": "https://doi.org/10.1016/j.cell.2022.08.004"
+  },
+  "10.1016/j.cell.2022.11.002": {
+    "title": "Genome-wide data from medieval German Jews show that the Ashkenazi founder event pre-dated the 14th century",
+    "year": 2022,
+    "journal": "Cell",
+    "date": "2022-11-30",
+    "first_author": "Shamam Waldman",
+    "doi_link": "https://doi.org/10.1016/j.cell.2022.11.002"
+  },
+  "10.1016/j.cell.2022.11.024": {
+    "title": "The genetic history of Scandinavia from the Roman Iron Age to the present",
+    "year": 2023,
+    "journal": "Cell",
+    "date": "2023-01-05",
+    "first_author": "Ricardo Rodríguez-Varela",
+    "doi_link": "https://doi.org/10.1016/j.cell.2022.11.024"
+  },
+  "10.1016/j.cell.2023.10.018": {
+    "title": "A genetic history of the Balkans from Roman frontier to Slavic migrations",
+    "year": 2023,
+    "journal": "Cell",
+    "date": "2023-12-07",
+    "first_author": "Iñigo Olalde",
+    "doi_link": "https://doi.org/10.1016/j.cell.2023.10.018"
+  },
+  "10.1016/j.cub.2019.02.006": {
+    "title": "Survival of Late Pleistocene Hunter-Gatherer Ancestry in the Iberian Peninsula",
+    "year": 2019,
+    "journal": "Current Biology",
+    "date": "2019-03-14",
+    "first_author": "Vanessa Villalba-Mouco",
+    "doi_link": "https://doi.org/10.1016/j.cub.2019.02.006"
+  },
+  "10.1016/j.cub.2019.04.026": {
+    "title": "The Arrival of Siberian Ancestry Connecting the Eastern Baltic to Uralic Speakers further East",
+    "year": 2019,
+    "journal": "Current Biology",
+    "date": "2019-05-09",
+    "first_author": "Lehti Saag",
+    "doi_link": "https://doi.org/10.1016/j.cub.2019.04.026"
+  },
+  "10.1016/j.cub.2019.06.019": {
+    "title": "Shifts in the Genetic Landscape of the Western Eurasian Steppe Associated with the Beginning and End of the Scythian Dominance",
+    "year": 2019,
+    "journal": "Current Biology",
+    "date": "2019-07-11",
+    "first_author": "Mari Järve",
+    "doi_link": "https://doi.org/10.1016/j.cub.2019.06.019"
+  },
+  "10.1016/j.cub.2019.06.044": {
+    "title": "Ancient Genomes Reveal Yamnaya-Related Ancestry and a Potential Source of Indo-European Speakers in Iron Age Tianshan",
+    "year": 2019,
+    "journal": "Current Biology",
+    "date": "2019-07-25",
+    "first_author": "Chao Ning",
+    "doi_link": "https://doi.org/10.1016/j.cub.2019.06.044"
+  },
+  "10.1016/j.cub.2020.09.035": {
+    "title": "Three Phases of Ancient Migration Shaped the Ancestry of Human Populations in Vanuatu",
+    "year": 2020,
+    "journal": "Current Biology",
+    "date": "2020-10-15",
+    "first_author": "Mark Lipson",
+    "doi_link": "https://doi.org/10.1016/j.cub.2020.09.035"
+  },
+  "10.1016/j.cub.2021.04.022": {
+    "title": "Ancient genomes reveal structural shifts after the arrival of Steppe-related ancestry in the Italian Peninsula",
+    "year": 2021,
+    "journal": "Current Biology",
+    "date": "2021-05-10",
+    "first_author": "Tina Saupe",
+    "doi_link": "https://doi.org/10.1016/j.cub.2021.04.022"
+  },
+  "10.1016/j.cub.2022.04.069": {
+    "title": "Ancient Maltese genomes and the genetic geography of Neolithic Europe",
+    "year": 2022,
+    "journal": "Current Biology",
+    "date": "2022-05-18",
+    "first_author": "Bruno Ariano",
+    "doi_link": "https://doi.org/10.1016/j.cub.2022.04.069"
+  },
+  "10.1016/j.cub.2022.04.093": {
+    "title": "The genetic origin of Huns, Avars, and conquering Hungarians",
+    "year": 2022,
+    "journal": "Current Biology",
+    "date": "2022-05-25",
+    "first_author": "Zoltán Maróti",
+    "doi_link": "https://doi.org/10.1016/j.cub.2022.04.093"
+  },
+  "10.1016/j.cub.2022.06.004": {
+    "title": "Northeastern Asian and Jomon-related genetic structure in the Three Kingdoms period of Gimhae, Korea",
+    "year": 2022,
+    "journal": "Current Biology",
+    "date": "2022-06-21",
+    "first_author": "Pere Gelabert",
+    "doi_link": "https://doi.org/10.1016/j.cub.2022.06.004"
+  },
+  "10.1016/j.cub.2022.06.016": {
+    "title": "A Late Pleistocene human genome from Southwest China",
+    "year": 2022,
+    "journal": "Current Biology",
+    "date": "2022-07-14",
+    "first_author": "Xiaoming Zhang",
+    "doi_link": "https://doi.org/10.1016/j.cub.2022.06.016"
+  },
+  "10.1016/j.cub.2022.08.036": {
+    "title": "Genomes from a medieval mass burial show Ashkenazi-associated hereditary diseases pre-date the 12th century",
+    "year": 2022,
+    "journal": "Current Biology",
+    "date": "2022-08-30",
+    "first_author": "Selina Brace",
+    "doi_link": "https://doi.org/10.1016/j.cub.2022.08.036"
+  },
+  "10.1016/j.cub.2022.11.034": {
+    "title": "Spatial and temporal heterogeneity in human mobility patterns in Holocene Southwest Asia and the East Mediterranean",
+    "year": 2023,
+    "journal": "Current Biology",
+    "date": "2022-12-08",
+    "first_author": "Dilek Koptekin",
+    "doi_link": "https://doi.org/10.1016/j.cub.2022.11.034"
+  },
+  "10.1016/j.cub.2022.11.062": {
+    "title": "Middle Holocene Siberian genomes reveal highly connected gene pools throughout North Asia",
+    "year": 2023,
+    "journal": "Current Biology",
+    "date": "2023-01-12",
+    "first_author": "Ke Wang",
+    "doi_link": "https://doi.org/10.1016/j.cub.2022.11.062"
+  },
+  "10.1016/j.cub.2023.02.041": {
+    "title": "Genomic analyses of hair from Ludwig van Beethoven",
+    "year": 2023,
+    "journal": "Current Biology",
+    "date": "2023-03-22",
+    "first_author": "Tristan James Alexander Begg",
+    "doi_link": "https://doi.org/10.1016/j.cub.2023.02.041"
+  },
+  "10.1016/j.isci.2021.102383": {
+    "title": "No particular genomic features underpin the dramatic economic consequences of 17th century plague epidemics in Italy",
+    "year": 2021,
+    "journal": "iScience",
+    "date": "2021-04-01",
+    "first_author": "Andaine Seguin-Orlando",
+    "doi_link": "https://doi.org/10.1016/j.isci.2021.102383"
+  },
+  "10.1016/j.isci.2022.104094": {
+    "title": "Origin and mobility of Iron Age Gaulish groups in present-day France revealed through archaeogenomics",
+    "year": 2022,
+    "journal": "iScience",
+    "date": "2022-03-16",
+    "first_author": "Claire-Elise Fischer",
+    "doi_link": "https://doi.org/10.1016/j.isci.2022.104094"
+  },
+  "10.1016/j.isci.2022.104244": {
+    "title": "Genomic and dietary discontinuities during the Mesolithic and Neolithic in Sicily",
+    "year": 2022,
+    "journal": "iScience",
+    "date": "2022-04-12",
+    "first_author": "He Yu",
+    "doi_link": "https://doi.org/10.1016/j.isci.2022.104244"
+  },
+  "10.1016/j.isci.2022.105636": {
+    "title": "Cultural and demic co-diffusion of Tubo Empire on Tibetan Plateau",
+    "year": 2022,
+    "journal": "iScience",
+    "date": "2022-11-21",
+    "first_author": "Kongyang Zhu",
+    "doi_link": "https://doi.org/10.1016/j.isci.2022.105636"
+  },
+  "10.1016/j.xgen.2023.100377": {
+    "title": "High-coverage genome of the Tyrolean Iceman reveals unusually high Anatolian farmer ancestry",
+    "year": 2023,
+    "journal": "Cell Genomics",
+    "date": "2023-08-16",
+    "first_author": "Ke Wang",
+    "doi_link": "https://doi.org/10.1016/j.xgen.2023.100377"
+  },
+  "10.1016/j.xgen.2024.100507": {
+    "title": "Ancient genomes illuminate Eastern Arabian population history and adaptation against malaria",
+    "year": 2024,
+    "journal": "Cell Genomics",
+    "date": "2024-02-27",
+    "first_author": "Rui Martiniano",
+    "doi_link": "https://doi.org/10.1016/j.xgen.2024.100507"
+  },
+  "10.1038/nature06742": {
+    "title": "Genotype, haplotype and copy-number variation in worldwide human populations",
+    "year": 2008,
+    "journal": "Nature",
+    "date": "2008-02-20",
+    "first_author": "Mattias Jakobsson",
+    "doi_link": "https://doi.org/10.1038/nature06742"
+  },
+  "10.1038/nature09710": {
+    "title": "Genetic history of an archaic hominin group from Denisova Cave in Siberia",
+    "year": 2010,
+    "journal": "Nature",
+    "date": "2010-12-21",
+    "first_author": "David Reich",
+    "doi_link": "https://doi.org/10.1038/nature09710"
+  },
+  "10.1038/nature14317": {
+    "title": "Massive migration from the steppe was a source for Indo-European languages in Europe",
+    "year": 2015,
+    "journal": "Nature",
+    "date": "2015-03-03",
+    "first_author": "Wolfgang Haak",
+    "doi_link": "https://doi.org/10.1038/nature14317"
+  },
+  "10.1038/nature14895": {
+    "title": "Genetic evidence for two founding populations of the Americas",
+    "year": 2015,
+    "journal": "Nature",
+    "date": "2015-07-21",
+    "first_author": "Pontus Skoglund",
+    "doi_link": "https://doi.org/10.1038/nature14895"
+  },
+  "10.1038/nature18964": {
+    "title": "The Simons Genome Diversity Project: 300 genomes from 142 diverse populations",
+    "year": 2016,
+    "journal": "Nature",
+    "date": "2016-09-20",
+    "first_author": "Swapan Mallick",
+    "doi_link": "https://doi.org/10.1038/nature18964"
+  },
+  "10.1038/ncomms15694": {
+    "title": "Ancient Egyptian mummy genomes suggest an increase of Sub-Saharan African ancestry in post-Roman periods",
+    "year": 2017,
+    "journal": "Nature Communications",
+    "date": "2017-05-30",
+    "first_author": "Verena J. Schuenemann",
+    "doi_link": "https://doi.org/10.1038/ncomms15694"
+  },
+  "10.1038/s41467-018-02825-9": {
+    "title": "The genetic prehistory of the Baltic Sea region",
+    "year": 2018,
+    "journal": "Nature Communications",
+    "date": "2018-01-24",
+    "first_author": "Alissa Mittnik",
+    "doi_link": "https://doi.org/10.1038/s41467-018-02825-9"
+  },
+  "10.1038/s41467-018-07483-5": {
+    "title": "Ancient Fennoscandian genomes reveal origin and spread of Siberian ancestry in Europe",
+    "year": 2018,
+    "journal": "Nature Communications",
+    "date": "2018-11-21",
+    "first_author": "Thiseas C. Lamnidis",
+    "doi_link": "https://doi.org/10.1038/s41467-018-07483-5"
+  },
+  "10.1038/s41467-018-08220-8": {
+    "title": "Ancient human genome-wide data from a 3000-year interval in the Caucasus corresponds with eco-geographic regions",
+    "year": 2019,
+    "journal": "Nature Communications",
+    "date": "2019-02-03",
+    "first_author": "Chuan-Chao Wang",
+    "doi_link": "https://doi.org/10.1038/s41467-018-08220-8"
+  },
+  "10.1038/s41467-019-09209-7": {
+    "title": "Late Pleistocene human genome suggests a local origin for the first farmers of central Anatolia",
+    "year": 2019,
+    "journal": "Nature Communications",
+    "date": "2019-04-16",
+    "first_author": "Michal Feldman",
+    "doi_link": "https://doi.org/10.1038/s41467-019-09209-7"
+  },
+  "10.1038/s41467-019-11357-9": {
+    "title": "Ancient DNA from the skeletons of Roopkund Lake reveals Mediterranean migrants in India",
+    "year": 2019,
+    "journal": "Nature Communications",
+    "date": "2019-08-20",
+    "first_author": "Éadaoin Harney",
+    "doi_link": "https://doi.org/10.1038/s41467-019-11357-9"
+  },
+  "10.1038/s41467-019-13549-9": {
+    "title": "A 5700 year-old human genome and oral microbiome from chewed birch pitch",
+    "year": 2019,
+    "journal": "Nature Communications",
+    "date": "2019-12-17",
+    "first_author": "Theis Z. T. Jensen",
+    "doi_link": "https://doi.org/10.1038/s41467-019-13549-9"
+  },
+  "10.1038/s41467-020-15020-6": {
+    "title": "Differential DNA methylation of vocal and facial anatomy genes in modern humans",
+    "year": 2020,
+    "journal": "Nature Communications",
+    "date": "2020-03-04",
+    "first_author": "David Gokhman",
+    "doi_link": "https://doi.org/10.1038/s41467-020-15020-6"
+  },
+  "10.1038/s41467-020-16557-2": {
+    "title": "Ancient genomes from northern China suggest links between subsistence changes and human migration",
+    "year": 2020,
+    "journal": "Nature Communications",
+    "date": "2020-06-01",
+    "first_author": "Chao Ning",
+    "doi_link": "https://doi.org/10.1038/s41467-020-16557-2"
+  },
+  "10.1038/s41467-020-17656-w": {
+    "title": "Ancient genomes in South Patagonia reveal population movements associated with technological shifts and geography",
+    "year": 2020,
+    "journal": "Nature Communications",
+    "date": "2020-08-03",
+    "first_author": "Nathan Nakatsuka",
+    "doi_link": "https://doi.org/10.1038/s41467-020-17656-w"
+  },
+  "10.1038/s41467-021-27356-8": {
+    "title": "Social stratification without genetic differentiation at the site of Kulubnarti in Christian Period Nubia",
+    "year": 2021,
+    "journal": "Nature Communications",
+    "date": "2021-12-14",
+    "first_author": "Kendra A. Sirak",
+    "doi_link": "https://doi.org/10.1038/s41467-021-27356-8"
+  },
+  "10.1038/s41467-022-28827-2": {
+    "title": "Ancient genomes from the Himalayas illuminate the genetic history of Tibetans and their Tibeto-Burman speaking neighbors",
+    "year": 2022,
+    "journal": "Nature Communications",
+    "date": "2022-03-08",
+    "first_author": "Chi-Chun Liu",
+    "doi_link": "https://doi.org/10.1038/s41467-022-28827-2"
+  },
+  "10.1038/s41467-022-29158-y": {
+    "title": "South-to-north migration preceded the advent of intensive farming in the Maya region",
+    "year": 2022,
+    "journal": "Nature Communications",
+    "date": "2022-03-22",
+    "first_author": "Douglas J. Kennett",
+    "doi_link": "https://doi.org/10.1038/s41467-022-29158-y"
+  },
+  "10.1038/s41467-023-40072-9": {
+    "title": "Patrilocality and hunter-gatherer-related ancestry of populations in East-Central Europe during the Middle Bronze Age",
+    "year": 2023,
+    "journal": "Nature Communications",
+    "date": "2023-08-01",
+    "first_author": "Maciej Chyleński",
+    "doi_link": "https://doi.org/10.1038/s41467-023-40072-9"
+  },
+  "10.1038/s41559-021-01443-x": {
+    "title": "A genome sequence from a modern human skull over 45,000 years old from Zlatý kůň in Czechia",
+    "year": 2021,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2021-04-07",
+    "first_author": "Kay Prüfer",
+    "doi_link": "https://doi.org/10.1038/s41559-021-01443-x"
+  },
+  "10.1038/s41559-022-01775-2": {
+    "title": "Ancient genomes from the last three millennia support multiple human dispersals into Wallacea",
+    "year": 2022,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2022-06-09",
+    "first_author": "Sandra Oliveira",
+    "doi_link": "https://doi.org/10.1038/s41559-022-01775-2"
+  },
+  "10.1038/s41559-023-01987-0": {
+    "title": "A 23,000-year-old southern Iberian individual links human groups that lived in Western Europe before and after the Last Glacial Maximum",
+    "year": 2023,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2023-03-01",
+    "first_author": "Vanessa Villalba-Mouco",
+    "doi_link": "https://doi.org/10.1038/s41559-023-01987-0"
+  },
+  "10.1038/s41559-023-02114-9": {
+    "title": "Genomic history of coastal societies from eastern South America",
+    "year": 2023,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2023-07-31",
+    "first_author": "Tiago Ferraz",
+    "doi_link": "https://doi.org/10.1038/s41559-023-02114-9"
+  },
+  "10.1038/s41559-023-02143-4": {
+    "title": "A genetic history of continuity and mobility in the Iron Age central Mediterranean",
+    "year": 2023,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2023-08-17",
+    "first_author": "Hannah M. Moots",
+    "doi_link": "https://doi.org/10.1038/s41559-023-02143-4"
+  },
+  "10.1038/s41559-023-02211-9": {
+    "title": "Genome sequences of 36,000- to 37,000-year-old modern humans at Buran-Kaya III in Crimea",
+    "year": 2023,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2023-10-23",
+    "first_author": "E. Andrew Bennett",
+    "doi_link": "https://doi.org/10.1038/s41559-023-02211-9"
+  },
+  "10.1038/s41562-024-01888-7": {
+    "title": "Evidence for dynastic succession among early Celtic elites in Central Europe",
+    "year": 2024,
+    "journal": "Nature Human Behaviour",
+    "date": "2024-06-03",
+    "first_author": "Joscha Gretzinger",
+    "doi_link": "https://doi.org/10.1038/s41562-024-01888-7"
+  },
+  "10.1038/s41586-019-1279-z": {
+    "title": "The population history of northeastern Siberia since the Pleistocene",
+    "year": 2019,
+    "journal": "Nature",
+    "date": "2019-06-05",
+    "first_author": "Martin Sikora",
+    "doi_link": "https://doi.org/10.1038/s41586-019-1279-z"
+  },
+  "10.1038/s41586-020-2378-6": {
+    "title": "A dynastic elite in monumental Neolithic society",
+    "year": 2020,
+    "journal": "Nature",
+    "date": "2020-06-17",
+    "first_author": "Lara M. Cassidy",
+    "doi_link": "https://doi.org/10.1038/s41586-020-2378-6"
+  },
+  "10.1038/s41586-021-03335-3": {
+    "title": "Initial Upper Palaeolithic humans in Europe had recent Neanderthal ancestry",
+    "year": 2021,
+    "journal": "Nature",
+    "date": "2021-04-07",
+    "first_author": "Mateja Hajdinjak",
+    "doi_link": "https://doi.org/10.1038/s41586-021-03335-3"
+  },
+  "10.1038/s41586-021-04052-7": {
+    "title": "The genomic origins of the Bronze Age Tarim Basin mummies",
+    "year": 2021,
+    "journal": "Nature",
+    "date": "2021-10-27",
+    "first_author": "Fan Zhang",
+    "doi_link": "https://doi.org/10.1038/s41586-021-04052-7"
+  },
+  "10.1038/s41586-021-04108-8": {
+    "title": "Triangulation supports agricultural spread of the Transeurasian languages",
+    "year": 2021,
+    "journal": "Nature",
+    "date": "2021-11-10",
+    "first_author": "Martine Robbeets",
+    "doi_link": "https://doi.org/10.1038/s41586-021-04108-8"
+  },
+  "10.1038/s41586-021-04241-4": {
+    "title": "A high-resolution picture of kinship practices in an Early Neolithic tomb",
+    "year": 2022,
+    "journal": "Nature",
+    "date": "2021-12-22",
+    "first_author": "Chris Fowler",
+    "doi_link": "https://doi.org/10.1038/s41586-021-04241-4"
+  },
+  "10.1038/s41586-021-04287-4": {
+    "title": "Large-scale migration into Britain during the Middle to Late Bronze Age",
+    "year": 2022,
+    "journal": "Nature",
+    "date": "2021-12-22",
+    "first_author": "Nick Patterson",
+    "doi_link": "https://doi.org/10.1038/s41586-021-04287-4"
+  },
+  "10.1038/s41586-022-04430-9": {
+    "title": "Ancient DNA and deep population structure in sub-Saharan African foragers",
+    "year": 2022,
+    "journal": "Nature",
+    "date": "2022-02-23",
+    "first_author": "Mark Lipson",
+    "doi_link": "https://doi.org/10.1038/s41586-022-04430-9"
+  },
+  "10.1038/s41586-022-04800-3": {
+    "title": "The source of the Black Death in fourteenth-century central Eurasia",
+    "year": 2022,
+    "journal": "Nature",
+    "date": "2022-06-15",
+    "first_author": "Maria A. Spyrou",
+    "doi_link": "https://doi.org/10.1038/s41586-022-04800-3"
+  },
+  "10.1038/s41586-023-05726-0": {
+    "title": "Palaeogenomics of Upper Palaeolithic to Neolithic European hunter-gatherers",
+    "year": 2023,
+    "journal": "Nature",
+    "date": "2023-03-01",
+    "first_author": "Cosimo Posth",
+    "doi_link": "https://doi.org/10.1038/s41586-023-05726-0"
+  },
+  "10.1038/s41586-023-05754-w": {
+    "title": "Entwined African and Asian genetic roots of medieval peoples of the Swahili coast",
+    "year": 2023,
+    "journal": "Nature",
+    "date": "2023-03-29",
+    "first_author": "Esther S. Brielle",
+    "doi_link": "https://doi.org/10.1038/s41586-023-05754-w"
+  },
+  "10.1038/s41586-023-06166-6": {
+    "title": "Northwest African Neolithic initiated by migrants from Iberia and Levant",
+    "year": 2023,
+    "journal": "Nature",
+    "date": "2023-06-07",
+    "first_author": "Luciana G. Simões",
+    "doi_link": "https://doi.org/10.1038/s41586-023-06166-6"
+  },
+  "10.1038/s41586-023-06350-8": {
+    "title": "Extensive pedigrees reveal the social organization of a Neolithic community",
+    "year": 2023,
+    "journal": "Nature",
+    "date": "2023-07-26",
+    "first_author": "Maïté Rivollat",
+    "doi_link": "https://doi.org/10.1038/s41586-023-06350-8"
+  },
+  "10.1038/s41586-023-06618-z": {
+    "title": "Elevated genetic risk for multiple sclerosis emerged in steppe pastoralist populations",
+    "year": 2024,
+    "journal": "Nature",
+    "date": "2024-01-10",
+    "first_author": "William Barrie",
+    "doi_link": "https://doi.org/10.1038/s41586-023-06618-z"
+  },
+  "10.1038/s41586-023-06771-5": {
+    "title": "Genetic continuity and change among the Indigenous peoples of California",
+    "year": 2023,
+    "journal": "Nature",
+    "date": "2023-11-22",
+    "first_author": "Nathan Nakatsuka",
+    "doi_link": "https://doi.org/10.1038/s41586-023-06771-5"
+  },
+  "10.1038/s41586-023-06865-0": {
+    "title": "Population genomics of post-glacial western Eurasia",
+    "year": 2024,
+    "journal": "Nature",
+    "date": "2024-01-10",
+    "first_author": "Morten E. Allentoft",
+    "doi_link": "https://doi.org/10.1038/s41586-023-06865-0"
+  },
+  "10.1038/s41586-024-07312-4": {
+    "title": "Network of large pedigrees reveals social practices of Avar communities",
+    "year": 2024,
+    "journal": "Nature",
+    "date": "2024-04-24",
+    "first_author": "Guido Alberto Gnecchi-Ruscone",
+    "doi_link": "https://doi.org/10.1038/s41586-024-07312-4"
+  },
+  "10.1038/s41586-024-07509-7": {
+    "title": "Ancient genomes reveal insights into ritual life at Chichén Itzá",
+    "year": 2024,
+    "journal": "Nature",
+    "date": "2024-06-12",
+    "first_author": "Rodrigo Barquera",
+    "doi_link": "https://doi.org/10.1038/s41586-024-07509-7"
+  },
+  "10.1038/s41598-018-35667-y": {
+    "title": "Ancient DNA of Phoenician remains indicates discontinuity in the settlement history of Ibiza",
+    "year": 2018,
+    "journal": "Scientific Reports",
+    "date": "2018-11-28",
+    "first_author": "Pierre Zalloua",
+    "doi_link": "https://doi.org/10.1038/s41598-018-35667-y"
+  },
+  "10.1038/s41598-019-56029-2": {
+    "title": "Interactions between earliest Linearbandkeramik farmers and central European hunter gatherers at the dawn of European Neolithization",
+    "year": 2019,
+    "journal": "Scientific Reports",
+    "date": "2019-12-20",
+    "first_author": "Alexey G. Nikitin",
+    "doi_link": "https://doi.org/10.1038/s41598-019-56029-2"
+  },
+  "10.1038/s41598-020-61190-0": {
+    "title": "Gene-flow from steppe individuals into Cucuteni-Trypillia associated populations indicates long-standing contacts and gradual admixture",
+    "year": 2020,
+    "journal": "Scientific Reports",
+    "date": "2020-03-06",
+    "first_author": "Alexander Immel",
+    "doi_link": "https://doi.org/10.1038/s41598-020-61190-0"
+  },
+  "10.1038/s41598-020-63138-w": {
+    "title": "Corded Ware cultural complexity uncovered using genomic and isotopic analysis from south-eastern Poland",
+    "year": 2020,
+    "journal": "Scientific Reports",
+    "date": "2020-04-17",
+    "first_author": "Anna Linderholm",
+    "doi_link": "https://doi.org/10.1038/s41598-020-63138-w"
+  },
+  "10.1038/s41598-021-95996-3": {
+    "title": "Biomolecular insights into North African-related ancestry, mobility and diet in eleventh-century Al-Andalus",
+    "year": 2021,
+    "journal": "Scientific Reports",
+    "date": "2021-09-13",
+    "first_author": "Marina Silva",
+    "doi_link": "https://doi.org/10.1038/s41598-021-95996-3"
+  },
+  "10.1038/s41598-022-10899-1": {
+    "title": "Bioarchaeological and palaeogenomic portrait of two Pompeians that died during the eruption of Vesuvius in 79 AD",
+    "year": 2022,
+    "journal": "Scientific Reports",
+    "date": "2022-05-26",
+    "first_author": "Gabriele Scorrano",
+    "doi_link": "https://doi.org/10.1038/s41598-022-10899-1"
+  },
+  "10.1038/s41598-022-11117-8": {
+    "title": "Genomes from Verteba cave suggest diversity within the Trypillians in Ukraine",
+    "year": 2022,
+    "journal": "Scientific Reports",
+    "date": "2022-05-04",
+    "first_author": "Pere Gelabert",
+    "doi_link": "https://doi.org/10.1038/s41598-022-11117-8"
+  },
+  "10.1038/s41598-022-25384-y": {
+    "title": "4000-year-old hair from the Middle Nile highlights unusual ancient DNA degradation pattern and a potential source of early eastern Africa pastoralists",
+    "year": 2022,
+    "journal": "Scientific Reports",
+    "date": "2022-12-03",
+    "first_author": "Ke Wang",
+    "doi_link": "https://doi.org/10.1038/s41598-022-25384-y"
+  },
+  "10.1038/s41598-022-26799-3": {
+    "title": "Ancient DNA from Protohistoric Period Cambodia indicates that South Asians admixed with local populations as early as 1st–3rd centuries CE",
+    "year": 2022,
+    "journal": "Scientific Reports",
+    "date": "2022-12-29",
+    "first_author": "Piya Changmai",
+    "doi_link": "https://doi.org/10.1038/s41598-022-26799-3"
+  },
+  "10.1038/s41598-024-54462-6": {
+    "title": "Kinship practices at the early bronze age site of Leubingen in Central Germany",
+    "year": 2024,
+    "journal": "Scientific Reports",
+    "date": "2024-02-16",
+    "first_author": "Sandra Penske",
+    "doi_link": "https://doi.org/10.1038/s41598-024-54462-6"
+  },
+  "10.1038/s41598-024-61052-z": {
+    "title": "Bioarchaeology aids the cultural understanding of six characters in search of their agency (Tarquinia, ninth–seventh century BC, central Italy)",
+    "year": 2024,
+    "journal": "Scientific Reports",
+    "date": "2024-05-28",
+    "first_author": "G. Bagnasco",
+    "doi_link": "https://doi.org/10.1038/s41598-024-61052-z"
+  },
+  "10.1038/s42003-022-03508-4": {
+    "title": "Bioarchaeological evidence of one of the earliest Islamic burials in the Levant",
+    "year": 2022,
+    "journal": "Communications Biology",
+    "date": "2022-06-07",
+    "first_author": "Megha Srigyan",
+    "doi_link": "https://doi.org/10.1038/s42003-022-03508-4"
+  },
+  "10.1038/s42003-022-04190-2": {
+    "title": "Genomic ancestry, diet and microbiomes of Upper Palaeolithic hunter-gatherers from San Teodoro cave",
+    "year": 2022,
+    "journal": "Communications Biology",
+    "date": "2022-11-18",
+    "first_author": "Gabriele Scorrano",
+    "doi_link": "https://doi.org/10.1038/s42003-022-04190-2"
+  },
+  "10.1038/s42003-023-04681-w": {
+    "title": "Genome-wide analysis of a collective grave from Mentesh Tepe provides insight into the population structure of early neolithic population in the South Caucasus",
+    "year": 2023,
+    "journal": "Communications Biology",
+    "date": "2023-03-25",
+    "first_author": "Perle Guarino-Vignon",
+    "doi_link": "https://doi.org/10.1038/s42003-023-04681-w"
+  },
+  "10.1038/s42003-023-05131-3": {
+    "title": "Genetic continuity, isolation, and gene flow in Stone Age Central and Eastern Europe",
+    "year": 2023,
+    "journal": "Communications Biology",
+    "date": "2023-08-09",
+    "first_author": "Tiina M. Mattila",
+    "doi_link": "https://doi.org/10.1038/s42003-023-05131-3"
+  },
+  "10.1073/pnas.1421784112": {
+    "title": "Genome-wide ancestry of 17th-century enslaved Africans from the Caribbean",
+    "year": 2015,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2015-03-10",
+    "first_author": "Hannes Schroeder",
+    "doi_link": "https://doi.org/10.1073/pnas.1421784112"
+  },
+  "10.1073/pnas.1813608115": {
+    "title": "Bronze Age population dynamics and the rise of dairy pastoralism on the eastern Eurasian steppe",
+    "year": 2018,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2018-11-05",
+    "first_author": "Choongwon Jeong",
+    "doi_link": "https://doi.org/10.1073/pnas.1813608115"
+  },
+  "10.1073/pnas.1818037116": {
+    "title": "Megalithic tombs in western and northern Neolithic Europe were linked to a kindred society",
+    "year": 2019,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2019-04-18",
+    "first_author": "Federico Sánchez-Quinto",
+    "doi_link": "https://doi.org/10.1073/pnas.1818037116"
+  },
+  "10.1073/pnas.1820210116": {
+    "title": "Unraveling ancestry, kinship, and violence in a Late Neolithic mass grave",
+    "year": 2019,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2019-05-14",
+    "first_author": "Hannes Schroeder",
+    "doi_link": "https://doi.org/10.1073/pnas.1820210116"
+  },
+  "10.1073/pnas.1918034117": {
+    "title": "Ancient genomes from present-day France unveil 7,000 years of its demographic history",
+    "year": 2020,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2020-05-26",
+    "first_author": "Samantha Brunel",
+    "doi_link": "https://doi.org/10.1073/pnas.1918034117"
+  },
+  "10.1073/pnas.2005965117": {
+    "title": "Integration of ancient DNA with transdisciplinary dataset finds strong support for Inca resettlement in the south Peruvian coast",
+    "year": 2020,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2020-07-14",
+    "first_author": "Jacob L. Bongers",
+    "doi_link": "https://doi.org/10.1073/pnas.2005965117"
+  },
+  "10.1073/pnas.2108001119": {
+    "title": "Ancient DNA at the edge of the world: Continental immigration and the persistence of Neolithic male lineages in Bronze Age Orkney",
+    "year": 2022,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2022-02-07",
+    "first_author": "Katharina Dulias",
+    "doi_link": "https://doi.org/10.1073/pnas.2108001119"
+  },
+  "10.1073/pnas.2120786119": {
+    "title": "Ancient DNA gives new insights into a Norman Neolithic monumental cemetery dedicated to male elites",
+    "year": 2022,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2022-04-21",
+    "first_author": "Maïté Rivollat",
+    "doi_link": "https://doi.org/10.1073/pnas.2120786119"
+  },
+  "10.1073/pnas.2205272119": {
+    "title": "The diverse genetic origins of a Classical period Greek army",
+    "year": 2022,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2022-10-03",
+    "first_author": "Laurie J. Reitsema",
+    "doi_link": "https://doi.org/10.1073/pnas.2205272119"
+  },
+  "10.1073/pnas.2210611120": {
+    "title": "Isotopic and DNA analyses reveal multiscale PPNB mobility and migration across Southeastern Anatolia and the Southern Levant",
+    "year": 2023,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2023-01-17",
+    "first_author": "Xiaoran Wang",
+    "doi_link": "https://doi.org/10.1073/pnas.2210611120"
+  },
+  "10.1073/pnas.2303574120": {
+    "title": "Descent, marriage, and residence practices of a 3,800-year-old pastoral community in Central Eurasia",
+    "year": 2023,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2023-08-21",
+    "first_author": "Jens Blöcher",
+    "doi_link": "https://doi.org/10.1073/pnas.2303574120"
+  },
+  "10.1073/pnas.2310545121": {
+    "title": "Genomic ancestry and social dynamics of the last hunter-gatherers of Atlantic France",
+    "year": 2024,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2024-02-26",
+    "first_author": "Luciana G. Simões",
+    "doi_link": "https://doi.org/10.1073/pnas.2310545121"
+  },
+  "10.1080/03014460.2019.1623912": {
+    "title": "East Anglian early Neolithic monument burial linked to contemporary Megaliths",
+    "year": 2019,
+    "journal": "Annals of Human Biology",
+    "date": "2019-06-11",
+    "first_author": "Christiana L. Scheib",
+    "doi_link": "https://doi.org/10.1080/03014460.2019.1623912"
+  },
+  "10.1086/720748": {
+    "title": "A Bioarchaeological Investigation of Fraternal Stillborn Twins from Tell el-Hesi",
+    "year": 2022,
+    "journal": "Near Eastern Archaeology",
+    "date": "2022-08-30",
+    "first_author": "Jaime Ullinger",
+    "doi_link": "https://doi.org/10.1086/720748"
+  },
+  "10.1093/gbe/evab192": {
+    "title": "Whole-Genome Sequencing of a 900-Year-Old Human Skeleton Supports Two Past Migration Events from the Russian Far East to Northern Japan",
+    "year": 2021,
+    "journal": "Genome Biology and Evolution",
+    "date": "2021-08-18",
+    "first_author": "Takehiro Sato",
+    "doi_link": "https://doi.org/10.1093/gbe/evab192"
+  },
+  "10.1093/molbev/msab216": {
+    "title": "Genetic Continuity of Bronze Age Ancestry with Increased Steppe-Related Ancestry in Late Iron Age Uzbekistan",
+    "year": 2021,
+    "journal": "Molecular Biology and Evolution",
+    "date": "2021-07-27",
+    "first_author": "Vikas Kumar",
+    "doi_link": "https://doi.org/10.1093/molbev/msab216"
+  },
+  "10.1093/molbev/msac014": {
+    "title": "The Genetic Origin of Daunians and the Pan-Mediterranean Southern Italian Iron Age Context",
+    "year": 2022,
+    "journal": "Molecular Biology and Evolution",
+    "date": "2022-01-13",
+    "first_author": "Serena Aneli",
+    "doi_link": "https://doi.org/10.1093/molbev/msac014"
+  },
+  "10.1093/molbev/msac108": {
+    "title": "Population Genetics and Signatures of Selection in Early Neolithic European Farmers",
+    "year": 2022,
+    "journal": "Molecular Biology and Evolution",
+    "date": "2022-05-17",
+    "first_author": "Ainash Childebayeva",
+    "doi_link": "https://doi.org/10.1093/molbev/msac108"
+  },
+  "10.1093/pnasnexus/pgac047": {
+    "title": "The genomic prehistory of the Indigenous peoples of Uruguay",
+    "year": 2022,
+    "journal": "PNAS Nexus",
+    "date": "2022-04-21",
+    "first_author": "John Lindo",
+    "doi_link": "https://doi.org/10.1093/pnasnexus/pgac047"
+  },
+  "10.1098/rspb.2018.2288": {
+    "title": "A western route of prehistoric human migration from Africa into the Iberian Peninsula",
+    "year": 2019,
+    "journal": "Proceedings of the Royal Society B: Biological Sciences",
+    "date": "2019-01-23",
+    "first_author": "G. González-Fortes",
+    "doi_link": "https://doi.org/10.1098/rspb.2018.2288"
+  },
+  "10.1098/rspb.2019.1528": {
+    "title": "The genomic ancestry of the Scandinavian Battle Axe Culture people and their relation to the broader Corded Ware horizon",
+    "year": 2019,
+    "journal": "Proceedings of the Royal Society B: Biological Sciences",
+    "date": "2019-10-09",
+    "first_author": "Helena Malmström",
+    "doi_link": "https://doi.org/10.1098/rspb.2019.1528"
+  },
+  "10.1101/2022.06.12.495320": {
+    "title": "Technical Report on Ancient DNA analysis of 27 African Americans from Catoctin Furnace, Maryland",
+    "year": "2022",
+    "journal": "bioRxiv",
+    "date": "2022-06-15",
+    "first_author": "Éadaoin Harney",
+    "doi_link": "https://doi.org/10.1101/2022.06.12.495320"
+  },
+  "10.1101/2024.05.29.596386": {
+    "title": "Ancient genomes reveal Avar-Hungarian transformations in the 9th-10th centuries CE Carpathian Basin",
+    "year": "2024",
+    "journal": "bioRxiv",
+    "date": "2024-10-28",
+    "first_author": "Dániel Gerber",
+    "doi_link": "https://doi.org/10.1101/2024.05.29.596386"
+  },
+  "10.1126/sciadv.aao1262": {
+    "title": "Ancient genome-wide analyses infer kinship structure in an Early Medieval Alemannic graveyard",
+    "year": 2018,
+    "journal": "Science Advances",
+    "date": "2018-09-05",
+    "first_author": "Niall O’Sullivan",
+    "doi_link": "https://doi.org/10.1126/sciadv.aao1262"
+  },
+  "10.1126/sciadv.aau5064": {
+    "title": "Ancient nuclear genomes enable repatriation of Indigenous human remains",
+    "year": 2018,
+    "journal": "Science Advances",
+    "date": "2018-12-20",
+    "first_author": "Joanne L. Wright",
+    "doi_link": "https://doi.org/10.1126/sciadv.aau5064"
+  },
+  "10.1126/sciadv.aax0061": {
+    "title": "Ancient DNA sheds light on the genetic origins of early Iron Age Philistines",
+    "year": 2019,
+    "journal": "Science Advances",
+    "date": "2019-07-03",
+    "first_author": "Michal Feldman",
+    "doi_link": "https://doi.org/10.1126/sciadv.aax0061"
+  },
+  "10.1126/sciadv.aaz5344": {
+    "title": "Ancient genome-wide DNA from France highlights the complexity of interactions between Mesolithic hunter-gatherers and Neolithic farmers",
+    "year": 2020,
+    "journal": "Science Advances",
+    "date": "2020-05-29",
+    "first_author": "Maïté Rivollat",
+    "doi_link": "https://doi.org/10.1126/sciadv.aaz5344"
+  },
+  "10.1126/sciadv.abg7261": {
+    "title": "Ancient genomes reveal long-range influence of the pre-Columbian culture and site of Tiwanaku",
+    "year": 2021,
+    "journal": "Science Advances",
+    "date": "2021-09-24",
+    "first_author": "Danijela Popović",
+    "doi_link": "https://doi.org/10.1126/sciadv.abg7261"
+  },
+  "10.1126/sciadv.abh2419": {
+    "title": "Ancient genomics reveals tripartite origins of Japanese populations",
+    "year": 2021,
+    "journal": "Science Advances",
+    "date": "2021-09-17",
+    "first_author": "Niall P. Cooke",
+    "doi_link": "https://doi.org/10.1126/sciadv.abh2419"
+  },
+  "10.1126/sciadv.abi7038": {
+    "title": "Genomic transformation and social organization during the Copper Age–Bronze Age transition in southern Iberia",
+    "year": 2021,
+    "journal": "Science Advances",
+    "date": "2021-11-17",
+    "first_author": "Vanessa Villalba-Mouco",
+    "doi_link": "https://doi.org/10.1126/sciadv.abi7038"
+  },
+  "10.1126/sciadv.abi7673": {
+    "title": "The origin and legacy of the Etruscans through a 2000-year archeogenomic time transect",
+    "year": 2021,
+    "journal": "Science Advances",
+    "date": "2021-09-24",
+    "first_author": "Cosimo Posth",
+    "doi_link": "https://doi.org/10.1126/sciadv.abi7673"
+  },
+  "10.1126/sciadv.abo3609": {
+    "title": "A genomic snapshot of demographic and cultural dynamism in Upper Mesopotamia during the Neolithic Transition",
+    "year": 2022,
+    "journal": "Science Advances",
+    "date": "2022-11-04",
+    "first_author": "N. Ezgi Altınışık",
+    "doi_link": "https://doi.org/10.1126/sciadv.abo3609"
+  },
+  "10.1126/sciadv.add5582": {
+    "title": "Human genetic history on the Tibetan Plateau in the past 5100 years",
+    "year": 2023,
+    "journal": "Science Advances",
+    "date": "2023-03-17",
+    "first_author": "Hongru Wang",
+    "doi_link": "https://doi.org/10.1126/sciadv.add5582"
+  },
+  "10.1126/science.1153717": {
+    "title": "Worldwide Human Relationships Inferred from Genome-Wide Patterns of Variation",
+    "year": 2008,
+    "journal": "Science",
+    "date": "2008-02-21",
+    "first_author": "Jun Z. Li",
+    "doi_link": "https://doi.org/10.1126/science.1153717"
+  },
+  "10.1126/science.1188021": {
+    "title": "A Draft Sequence of the Neandertal Genome",
+    "year": 2010,
+    "journal": "Science",
+    "date": "2010-05-06",
+    "first_author": "Richard E. Green",
+    "doi_link": "https://doi.org/10.1126/science.1188021"
+  },
+  "10.1126/science.aar2625": {
+    "title": "Ancient genomes from Iceland reveal the making of a human population",
+    "year": 2018,
+    "journal": "Science",
+    "date": "2018-06-04",
+    "first_author": "S. Sunna Ebenesersdóttir",
+    "doi_link": "https://doi.org/10.1126/science.aar2625"
+  },
+  "10.1126/science.aar8380": {
+    "title": "Pleistocene North African genomes link Near Eastern and sub-Saharan African human populations",
+    "year": 2018,
+    "journal": "Science",
+    "date": "2018-03-15",
+    "first_author": "Marieke van de Loosdrecht",
+    "doi_link": "https://doi.org/10.1126/science.aar8380"
+  },
+  "10.1126/science.aax6219": {
+    "title": "Kinship-based social inequality in Bronze Age Europe",
+    "year": 2019,
+    "journal": "Science",
+    "date": "2019-10-10",
+    "first_author": "Alissa Mittnik",
+    "doi_link": "https://doi.org/10.1126/science.aax6219"
+  },
+  "10.1126/science.aay6826": {
+    "title": "Ancient Rome: A genetic crossroads of Europe and the Mediterranean",
+    "year": 2019,
+    "journal": "Science",
+    "date": "2019-11-08",
+    "first_author": "Margaret L. Antonio",
+    "doi_link": "https://doi.org/10.1126/science.aay6826"
+  },
+  "10.1126/science.aba0909": {
+    "title": "Ancient DNA indicates human population shifts and admixture in northern and southern China",
+    "year": 2020,
+    "journal": "Science",
+    "date": "2020-05-14",
+    "first_author": "Melinda A. Yang",
+    "doi_link": "https://doi.org/10.1126/science.aba0909"
+  },
+  "10.1126/science.abi8264": {
+    "title": "A unified genealogy of modern and ancient genomes",
+    "year": 2022,
+    "journal": "Science",
+    "date": "2022-02-24",
+    "first_author": "Anthony Wilder Wohns",
+    "doi_link": "https://doi.org/10.1126/science.abi8264"
+  },
+  "10.1126/science.abk1534": {
+    "title": "Bronze and Iron Age population movements underlie Xinjiang population history",
+    "year": 2022,
+    "journal": "Science",
+    "date": "2022-03-31",
+    "first_author": "Vikas Kumar",
+    "doi_link": "https://doi.org/10.1126/science.abk1534"
+  },
+  "10.1126/science.abm4247": {
+    "title": "The genetic history of the Southern Arc: A bridge between West Asia and Europe",
+    "year": 2022,
+    "journal": "Science",
+    "date": "2022-08-25",
+    "first_author": "Iosif Lazaridis",
+    "doi_link": "https://doi.org/10.1126/science.abm4247"
+  },
+  "10.1126/science.abm6536": {
+    "title": "Ancient DNA reveals five streams of migration into Micronesia and matrilocality in early Pacific seafarers",
+    "year": 2022,
+    "journal": "Science",
+    "date": "2022-06-30",
+    "first_author": "Yue-Chen Liu",
+    "doi_link": "https://doi.org/10.1126/science.abm6536"
+  },
+  "10.1126/science.add6142": {
+    "title": "Demographic history and genetic structure in pre-Hispanic Central Mexico",
+    "year": 2023,
+    "journal": "Science",
+    "date": "2023-05-11",
+    "first_author": "Viridiana Villa-Islas",
+    "doi_link": "https://doi.org/10.1126/science.add6142"
+  },
+  "10.1126/science.ade4995": {
+    "title": "The genetic legacy of African Americans from Catoctin Furnace",
+    "year": 2023,
+    "journal": "Science",
+    "date": "2023-08-08",
+    "first_author": "Éadaoin Harney",
+    "doi_link": "https://doi.org/10.1126/science.ade4995"
+  },
+  "10.1186/s13059-023-03013-9": {
+    "title": "Genetic history of East-Central Europe in the first millennium CE",
+    "year": 2023,
+    "journal": "Genome Biology",
+    "date": "2023-07-24",
+    "first_author": "Ireneusz Stolarek",
+    "doi_link": "https://doi.org/10.1186/s13059-023-03013-9"
+  },
+  "10.1371/journal.pone.0241278": {
+    "title": "Kinship and social organization in Copper Age Europe. A cross-disciplinary analysis of archaeology, DNA, isotopes, and anthropology from two Bell Beaker cemeteries",
+    "year": 2020,
+    "journal": "PLOS ONE",
+    "date": "2020-11-16",
+    "first_author": "Karl-Göran Sjögren",
+    "doi_link": "https://doi.org/10.1371/journal.pone.0241278"
+  },
+  "10.1371/journal.pone.0241883": {
+    "title": "Human mobility at Tell Atchana (Alalakh), Hatay, Turkey during the 2nd millennium BC: Integration of isotopic and genomic evidence",
+    "year": 2021,
+    "journal": "PLOS ONE",
+    "date": "2021-06-30",
+    "first_author": "Tara Ingman",
+    "doi_link": "https://doi.org/10.1371/journal.pone.0241883"
+  },
+  "10.1371/journal.pone.0285449": {
+    "title": "Interactions between Trypillian farmers and North Pontic forager-pastoralists in Eneolithic central Ukraine",
+    "year": 2023,
+    "journal": "PLOS ONE",
+    "date": "2023-06-14",
+    "first_author": "Alexey G. Nikitin",
+    "doi_link": "https://doi.org/10.1371/journal.pone.0285449"
+  },
+  "10.15184/aqy.2022.79": {
+    "title": "Life and death in early colonial Campeche: new insights from ancient DNA",
+    "year": 2022,
+    "journal": "Antiquity",
+    "date": "2022-07-13",
+    "first_author": "Vera Tiesler",
+    "doi_link": "https://doi.org/10.15184/aqy.2022.79"
+  },
+  "10.15184/aqy.2023.2": {
+    "title": "Kinship practices in Early Iron Age South-east Europe: genetic and isotopic analysis of burials from the Dolge njive barrow cemetery, Dolenjska, Slovenia",
+    "year": 2023,
+    "journal": "Antiquity",
+    "date": "2023-02-17",
+    "first_author": "Ian Armit",
+    "doi_link": "https://doi.org/10.15184/aqy.2023.2"
+  },
+  "10.15184/aqy.2024.94": {
+    "title": "High levels of consanguinity in a child from Paquimé, Chihuahua, Mexico",
+    "year": 2024,
+    "journal": "Antiquity",
+    "date": "2024-08-13",
+    "first_author": "Jakob Sedig",
+    "doi_link": "https://doi.org/10.15184/aqy.2024.94"
+  },
+  "10.21203/rs.3.rs-1993191/v1": {
+    "title": "First ancient DNA analysis of mummies from the post-Scythian Oglakhty cemetery in South Siberia",
+    "year": "2022",
+    "journal": "Research Square",
+    "date": "2022-08-29",
+    "first_author": "Artem Nedoluzhko",
+    "doi_link": "https://doi.org/10.21203/rs.3.rs-1993191/v1"
+  },
+  "10.2144/btn-2020-0100": {
+    "title": "Comparison of Target Enrichment Strategies for Ancient Pathogen DNA",
+    "year": 2020,
+    "journal": "BioTechniques",
+    "date": "2020-11-02",
+    "first_author": "Anja Furtwängler",
+    "doi_link": "https://doi.org/10.2144/btn-2020-0100"
+  },
+  "10.3390/genes13010136": {
+    "title": "First Glimpse into the Genomic Characterization of People from the Imperial Roman Community of Casal Bertone (Rome, First–Third Centuries AD)",
+    "year": 2022,
+    "journal": "Genes",
+    "date": "2022-01-13",
+    "first_author": "Flavio De Angelis",
+    "doi_link": "https://doi.org/10.3390/genes13010136"
+  },
+  "10.47248/hpgg2404010004": {
+    "title": "Medieval genomes from eastern Mongolia share a stable genetic profile over a millennium",
+    "year": 2024,
+    "journal": "Human Population Genetics and Genomics",
+    "date": "2024-03-01",
+    "first_author": "Juhyeon Lee",
+    "doi_link": "https://doi.org/10.47248/hpgg2404010004"
+  },
+  "10.7554/elife.79714": {
+    "title": "Stable population structure in Europe since the Iron Age, despite high mobility",
+    "year": 2024,
+    "journal": "eLife",
+    "date": "2023-12-12",
+    "first_author": "Margaret L Antonio",
+    "doi_link": "https://doi.org/10.7554/elife.79714"
+  },
+  "10.7554/elife.85492": {
+    "title": "On the limits of fitting complex models of population history to f-statistics",
+    "year": 2023,
+    "journal": "eLife",
+    "date": "2023-04-14",
+    "first_author": "Robert Maier",
+    "doi_link": "https://doi.org/10.7554/elife.85492"
+  },
+  "10.1038/s41431-019-0361-1": {
+    "title": "People from Ibiza: an unexpected isolate in the Western Mediterranean",
+    "year": 2019,
+    "journal": "European Journal of Human Genetics",
+    "date": "2019-02-14",
+    "first_author": "Simone Andrea Biagini",
+    "doi_link": "https://doi.org/10.1038/s41431-019-0361-1"
+  },
+  "10.1371/journal.pgen.1010036": {
+    "title": "Indian genetic heritage in Southeast Asian populations",
+    "year": 2022,
+    "journal": "PLOS Genetics",
+    "date": "2022-02-17",
+    "first_author": "Piya Changmai",
+    "doi_link": "https://doi.org/10.1371/journal.pgen.1010036"
+  },
+  "10.1038/s41598-020-75910-z": {
+    "title": "Early medieval genetic data from Ural region evaluated in the light of archaeological evidence of ancient Hungarians",
+    "year": 2020,
+    "journal": "Scientific Reports",
+    "date": "2020-11-05",
+    "first_author": "Veronika Csáky",
+    "doi_link": "https://doi.org/10.1038/s41598-020-75910-z"
+  },
+  "10.1038/s41467-020-15560-x": {
+    "title": "Ancient genomes reveal social and genetic structure of Late Neolithic Switzerland",
+    "year": 2020,
+    "journal": "Nature Communications",
+    "date": "2020-04-20",
+    "first_author": "Anja Furtwängler",
+    "doi_link": "https://doi.org/10.1038/s41467-020-15560-x"
+  },
+  "10.1038/s41586-024-08113-5": {
+    "title": "The rise and transformation of Bronze Age pastoralists in the Caucasus",
+    "year": 2024,
+    "journal": "Nature",
+    "date": "2024-10-30",
+    "first_author": "Ayshin Ghalichi",
+    "doi_link": "https://doi.org/10.1038/s41586-024-08113-5"
+  },
+  "10.55465/gbvn3319": {
+    "title": "Een Merovingische nederzetting en grafveld aan de Vlaamse kust. Een toevalsvondst aan de Ter Duinenlaan te Koksijde. Eindverslag",
+    "year": 2019,
+    "journal": "Onderzoeksrapporten agentschap Onroerend Erfgoed",
+    "date": "2022-06-14",
+    "first_author": "Marc Dewilde",
+    "doi_link": "https://doi.org/10.55465/gbvn3319"
+  },
+  "10.1126/sciadv.adg3377": {
+    "title": "Insights into the genetic histories and lifeways of Machu Picchu’s occupants",
+    "year": 2023,
+    "journal": "Science Advances",
+    "date": "2023-07-26",
+    "first_author": "Lucy Salazar",
+    "doi_link": "https://doi.org/10.1126/sciadv.adg3377"
+  },
+  "10.1073/pnas.2406734121": {
+    "title": "Capturing the fusion of two ancestries and kinship structures in Merovingian Flanders",
+    "year": 2024,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2024-06-24",
+    "first_author": "Stefania Sasso",
+    "doi_link": "https://doi.org/10.1073/pnas.2406734121"
+  },
+  "10.1073/pnas.2412355121": {
+    "title": "The genetic origins and impacts of historical Papuan migrations into Wallacea",
+    "year": 2024,
+    "journal": "Proceedings of the National Academy of Sciences",
+    "date": "2024-12-17",
+    "first_author": "Gludhug A. Purnomo",
+    "doi_link": "https://doi.org/10.1073/pnas.2412355121"
+  },
+  "10.1007/s12520-024-02050-0": {
+    "title": "Bioarchaeological Perspectives on Late Antiquity in Dalmatia: Paleogenetic, Dietary, and Population Studies of the Hvar—Radošević burial site",
+    "year": 2024,
+    "journal": "Archaeological and Anthropological Sciences",
+    "date": "2024-08-20",
+    "first_author": "Brina Zagorc",
+    "doi_link": "https://doi.org/10.1007/s12520-024-02050-0"
+  },
+  "10.1093/molbev/msae168": {
+    "title": "Low Genetic Impact of the Roman Occupation of Britain in Rural Communities",
+    "year": 2024,
+    "journal": "Molecular Biology and Evolution",
+    "date": "2024-09-13",
+    "first_author": "Christiana L Scheib",
+    "doi_link": "https://doi.org/10.1093/molbev/msae168"
+  },
+  "10.1126/sciadv.adi5903": {
+    "title": "Genetic history of Cambridgeshire before and after the Black Death",
+    "year": 2024,
+    "journal": "Science Advances",
+    "date": "2024-01-17",
+    "first_author": "Ruoyun Hui",
+    "doi_link": "https://doi.org/10.1126/sciadv.adi5903"
+  },
+  "10.1126/sciadv.adl2468": {
+    "title": "Late Neolithic collective burial reveals admixture dynamics during the third millennium BCE and the shaping of the European genome",
+    "year": 2024,
+    "journal": "Science Advances",
+    "date": "2024-06-19",
+    "first_author": "Oğuzhan Parasayan",
+    "doi_link": "https://doi.org/10.1126/sciadv.adl2468"
+  },
+  "10.1038/s41467-024-51087-1": {
+    "title": "Human genetic structure in Northwest France provides new insights into West European historical demography",
+    "year": 2024,
+    "journal": "Nature Communications",
+    "date": "2024-08-07",
+    "first_author": "Isabel Alves",
+    "doi_link": "https://doi.org/10.1038/s41467-024-51087-1"
+  },
+  "10.1038/s41598-024-54824-0": {
+    "title": "Biomolecular evidence for changing millet reliance in Late Bronze Age central Germany",
+    "year": 2024,
+    "journal": "Scientific Reports",
+    "date": "2024-02-22",
+    "first_author": "Eleftheria Orfanou",
+    "doi_link": "https://doi.org/10.1038/s41598-024-54824-0"
+  },
+  "10.1038/s41559-024-02322-x": {
+    "title": "Medieval DNA from Soqotra points to Eurasian origins of an isolated population at the crossroads of Africa and Arabia",
+    "year": 2024,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2024-02-08",
+    "first_author": "Kendra Sirak",
+    "doi_link": "https://doi.org/10.1038/s41559-024-02322-x"
+  },
+  "10.1038/s41467-023-40198-w": {
+    "title": "The genomic history of the indigenous people of the Canary Islands",
+    "year": 2023,
+    "journal": "Nature Communications",
+    "date": "2023-08-15",
+    "first_author": "Javier G. Serrano",
+    "doi_link": "https://doi.org/10.1038/s41467-023-40198-w"
+  },
+  "10.1016/j.isci.2023.106581": {
+    "title": "A paleogenome from a Holocene individual supports genetic continuity in Southeast Alaska",
+    "year": 2023,
+    "journal": "iScience",
+    "date": "2023-04-09",
+    "first_author": "Alber Aqil",
+    "doi_link": "https://doi.org/10.1016/j.isci.2023.106581"
+  },
+  "10.15184/aqy.2023.71": {
+    "title": "Investigating the prehistory of Luxembourg using ancient genomes",
+    "year": 2023,
+    "journal": "Antiquity",
+    "date": "2023-06-26",
+    "first_author": "Maxime Brami",
+    "doi_link": "https://doi.org/10.15184/aqy.2023.71"
+  },
+  "10.1093/molbev/msad182": {
+    "title": "Interdisciplinary Analyses of Bronze Age Communities from Western Hungary Reveal Complex Population Histories",
+    "year": 2023,
+    "journal": "Molecular Biology and Evolution",
+    "date": "2023-08-09",
+    "first_author": "Dániel Gerber",
+    "doi_link": "https://doi.org/10.1093/molbev/msad182"
+  },
+  "10.1371/journal.pgen.1010360": {
+    "title": "Imputed genomes and haplotype-based analyses of the Picts of early medieval Scotland reveal fine-scale relatedness between Iron Age, early medieval and the modern people of the UK",
+    "year": 2023,
+    "journal": "PLOS Genetics",
+    "date": "2023-04-27",
+    "first_author": "Adeline Morez",
+    "doi_link": "https://doi.org/10.1371/journal.pgen.1010360"
+  },
+  "10.1038/s41559-022-01883-z": {
+    "title": "Dual ancestries and ecologies of the Late Glacial Palaeolithic in Britain",
+    "year": 2022,
+    "journal": "Nature Ecology &amp; Evolution",
+    "date": "2022-10-24",
+    "first_author": "Sophy Charlton",
+    "doi_link": "https://doi.org/10.1038/s41559-022-01883-z"
+  },
+  "10.1093/molbev/msab351": {
+    "title": "Ancient Human Genomes and Environmental DNA from the Cement Attaching 2,000-Year-Old Head Lice Nits",
+    "year": 2022,
+    "journal": "Molecular Biology and Evolution",
+    "date": "2021-12-06",
+    "first_author": "Mikkel W Pedersen",
+    "doi_link": "https://doi.org/10.1093/molbev/msab351"
+  },
+  "10.1016/j.celrep.2021.109278": {
+    "title": "A 5,000-year-old hunter-gatherer already plagued by Yersinia pestis",
+    "year": 2021,
+    "journal": "Cell Reports",
+    "date": "2021-06-29",
+    "first_author": "Julian Susat",
+    "doi_link": "https://doi.org/10.1016/j.celrep.2021.109278"
+  },
+  "10.1016/j.ajhg.2021.07.012": {
+    "title": "Patterns of genetic connectedness between modern and medieval Estonian genomes reveal the origins of a major ancestry component of the Finnish population",
+    "year": 2021,
+    "journal": "The American Journal of Human Genetics",
+    "date": "2021-08-18",
+    "first_author": "Toomas Kivisild",
+    "doi_link": "https://doi.org/10.1016/j.ajhg.2021.07.012"
+  },
+  "10.1016/j.cub.2021.06.023": {
+    "title": "Genome-scale sequencing and analysis of human, wolf, and bison DNA from 25,000-year-old sediment",
+    "year": 2021,
+    "journal": "Current Biology",
+    "date": "2021-07-12",
+    "first_author": "Pere Gelabert",
+    "doi_link": "https://doi.org/10.1016/j.cub.2021.06.023"
+  },
+  "10.1038/s41598-020-75163-w": {
+    "title": "A systematic investigation of human DNA preservation in medieval skeletons",
+    "year": 2020,
+    "journal": "Scientific Reports",
+    "date": "2020-10-26",
+    "first_author": "Cody Parker",
+    "doi_link": "https://doi.org/10.1038/s41598-020-75163-w"
+  },
+  "10.1038/s41598-020-78723-2": {
+    "title": "A biomolecular anthropological investigation of William Adams, the first SAMURAI from England",
+    "year": 2020,
+    "journal": "Scientific Reports",
+    "date": "2020-12-10",
+    "first_author": "Fuzuki Mizuno",
+    "doi_link": "https://doi.org/10.1038/s41598-020-78723-2"
+  },
+  "10.15184/aqy.2025.10139": {
+    "title": "West African ancestry in seventh-century England: two individuals from Kent and Dorset",
+    "year": 2025,
+    "journal": "Antiquity",
+    "date": "2025-08-13",
+    "first_author": "Duncan Sayer",
+    "doi_link": "https://doi.org/10.15184/aqy.2025.10139"
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -271,7 +271,7 @@
                 <td>Iñigo Olalde</td>
                 <td>2026-02-11</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>112</td>
             </tr>
@@ -336,7 +336,7 @@
                 <td>Marina Silva</td>
                 <td>2025-12-24</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>1</td>
             </tr>
@@ -375,7 +375,7 @@
                 <td>Mattias Jakobsson</td>
                 <td>2025-12-03</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>28</td>
             </tr>
@@ -414,7 +414,7 @@
                 <td>Javier Maravall-López</td>
                 <td>2025-11-05</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>238</td>
             </tr>
@@ -427,7 +427,7 @@
                 <td>Aigerim Rymbekova</td>
                 <td>2025-11-04</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>9</td>
             </tr>
@@ -440,7 +440,7 @@
                 <td>Esha Bandyopadhyay</td>
                 <td>2025-10-29</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>8</td>
             </tr>
@@ -492,7 +492,7 @@
                 <td>Balázs Gyuris</td>
                 <td>2025-10-16</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>131</td>
             </tr>
@@ -531,7 +531,7 @@
                 <td>Tingyu Yang</td>
                 <td>2025-09-30</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>58</td>
             </tr>
@@ -609,7 +609,7 @@
                 <td>Xavier Roca-Rada</td>
                 <td>2025-08-18</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>67</td>
             </tr>
@@ -713,7 +713,7 @@
                 <td>Adeline Morez Jacobs</td>
                 <td>2025-07-02</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>1</td>
             </tr>
@@ -726,7 +726,7 @@
                 <td>Tian Chen Zeng</td>
                 <td>2025-07-02</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>195</td>
             </tr>
@@ -739,7 +739,7 @@
                 <td>Eren Yüncü</td>
                 <td>2025-06-26</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>131</td>
             </tr>
@@ -765,7 +765,7 @@
                 <td>Anna Szécsényi-Nagy</td>
                 <td>2025-06-24</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>125</td>
             </tr>
@@ -817,7 +817,7 @@
                 <td>Kathrin Nägele</td>
                 <td>2025-06-04</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>27</td>
             </tr>
@@ -843,7 +843,7 @@
                 <td>Owyn Beneker</td>
                 <td>2025-05-19</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>338</td>
             </tr>
@@ -856,7 +856,7 @@
                 <td>Motahareh Ala Amjadi</td>
                 <td>2025-05-13</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>20</td>
             </tr>
@@ -882,7 +882,7 @@
                 <td>Harald Ringbauer</td>
                 <td>2025-04-23</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>210</td>
             </tr>
@@ -908,7 +908,7 @@
                 <td>Iosif Lazaridis</td>
                 <td>2025-02-05</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>354</td>
             </tr>
@@ -921,7 +921,7 @@
                 <td>Juncen Liu</td>
                 <td>2025-02-03</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>85</td>
             </tr>
@@ -934,7 +934,7 @@
                 <td>Ke Wang</td>
                 <td>2025-01-15</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>722</td>
             </tr>
@@ -947,7 +947,7 @@
                 <td>Lara M. Cassidy</td>
                 <td>2025-01-15</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>57</td>
             </tr>
@@ -960,7 +960,7 @@
                 <td>Lehti Saag</td>
                 <td>2025-01-08</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>91</td>
             </tr>
@@ -999,7 +999,7 @@
                 <td>Minglei Lv</td>
                 <td>2024-11-20</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>7</td>
             </tr>
@@ -1012,7 +1012,7 @@
                 <td>Francesco Ravasini</td>
                 <td>2024-11-20</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>102</td>
             </tr>
@@ -1025,7 +1025,7 @@
                 <td>Ayshin Ghalichi</td>
                 <td>2024-10-30</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>131</td>
             </tr>
@@ -1051,7 +1051,7 @@
                 <td>Owen Alexander Higgins</td>
                 <td>2024-09-20</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>1</td>
             </tr>
@@ -1090,7 +1090,7 @@
                 <td>Ludovic Slimak</td>
                 <td>2024-09-11</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>1</td>
             </tr>
@@ -1103,7 +1103,7 @@
                 <td>Ricardo Rodríguez-Varela</td>
                 <td>2024-08-28</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>33</td>
             </tr>
@@ -1155,7 +1155,7 @@
                 <td>Isabel Alves</td>
                 <td>2024-08-07</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>6</td>
             </tr>
@@ -1194,7 +1194,7 @@
                 <td>Stefania Sasso</td>
                 <td>2024-06-24</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✔</td>
                 <td>48</td>
             </tr>
@@ -1207,7 +1207,7 @@
                 <td>Oğuzhan Parasayan</td>
                 <td>2024-06-19</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>8</td>
             </tr>
@@ -1337,7 +1337,7 @@
                 <td>Kendra Sirak</td>
                 <td>2024-02-08</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>39</td>
             </tr>
@@ -1350,7 +1350,7 @@
                 <td>Ruoyun Hui</td>
                 <td>2024-01-17</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>275</td>
             </tr>
@@ -1506,7 +1506,7 @@
                 <td>Javier G. Serrano</td>
                 <td>2023-08-15</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>40</td>
             </tr>
@@ -1532,7 +1532,7 @@
                 <td>Dániel Gerber</td>
                 <td>2023-08-09</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>21</td>
             </tr>
@@ -1688,7 +1688,7 @@
                 <td>Adeline Morez</td>
                 <td>2023-04-27</td>
                 <td>✘</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>2</td>
             </tr>
@@ -1831,7 +1831,7 @@
                 <td>Eirini Skourtanioti</td>
                 <td>2023-01-16</td>
                 <td>✔</td>
-                <td>✘</td>
+                <td>✔</td>
                 <td>✘</td>
                 <td>103</td>
             </tr>

--- a/docs/paper_directory.csv
+++ b/docs/paper_directory.csv
@@ -7,33 +7,33 @@ doi,title,year,journal,first_author,publication_date,community_archive,aadr_arch
 10.1038/s41467-026-69895-y,"Reconstruction of the lifeways of Central European Late Bronze Age communities using ancient DNA, isotope and osteoarchaeological analyses",2026,Nature Communications,Eleftheria Orfanou,2026-02-24,False,False,False,69
 10.1038/s41562-025-02399-9,A large mass grave from the Early Iron Age indicates selective violence towards women and children in the Carpathian Basin,2026,Nature Human Behaviour,Linda Fibiger,2026-02-23,False,False,False,25
 10.1098/rspb.2025.0813,Genetic relatedness mattered in the co-burial ritual of Neolithic hunter–gatherers,2026,Proceedings of the Royal Society B: Biological Sciences,Tiina Maria Mattila,2026-02-18,False,False,False,10
-10.1038/s41586-026-10111-8,Lasting Lower Rhine–Meuse forager ancestry shaped Bell Beaker expansion,2026,Nature,Iñigo Olalde,2026-02-11,False,False,False,112
+10.1038/s41586-026-10111-8,Lasting Lower Rhine–Meuse forager ancestry shaped Bell Beaker expansion,2026,Nature,Iñigo Olalde,2026-02-11,False,True,False,112
 10.1186/s13059-026-03968-5,Genetic affinities between the ancient Greek colony of Amvrakia and its metropolis,2026,Genome Biology,Nikolaos Psonis,2026-02-07,False,False,False,26
 10.1186/s13059-026-03969-4,Cosmopolitanism in the depths of Barbaricum evidenced by archaeogenomic data from the Late Iron Age Goth community of the Masłomęcz group,2026,Genome Biology,Michał Golubiński,2026-01-28,False,False,False,37
 10.1038/s41586-025-09856-5,An ancient DNA perspective on the Russian conquest of Yakutia,2026,Nature,Éric Crubézy,2026-01-07,False,False,False,105
 10.1038/s41467-025-67906-y,Tracing social mechanisms and interregional connections in Early Bronze Age Societies in Lower Austria,2025,Nature Communications,Anja Furtwängler,2025-12-31,False,False,False,129
-10.1016/j.jasrep.2025.105559,"Genetic and historical perspectives on the early medieval inhumations from the Menga dolmen, Antequera (Spain)",2026,Journal of Archaeological Science: Reports,Marina Silva,2025-12-24,False,False,False,1
+10.1016/j.jasrep.2025.105559,"Genetic and historical perspectives on the early medieval inhumations from the Menga dolmen, Antequera (Spain)",2026,Journal of Archaeological Science: Reports,Marina Silva,2025-12-24,False,True,False,1
 10.1038/s42003-025-09194-2,Archaeogenetics reconstructs demography and extreme parental consanguinity in a Bronze Age community from Southern Italy,2025,Communications Biology,Francesco Fontani,2025-12-15,False,False,False,14
 10.64898/2025.12.07.692553,"Ancestry, admixture, and pathogens in contemporaneous Neolithic farmers and foragers on the Island of Gotland",0,No Journal,Magdalena Fraser,2025-12-10,False,False,False,2
-10.1038/s41586-025-09811-4,Homo sapiens-specific evolution unveiled by ancient southern African genomes,2026,Nature,Mattias Jakobsson,2025-12-03,False,False,False,28
+10.1038/s41586-025-09811-4,Homo sapiens-specific evolution unveiled by ancient southern African genomes,2026,Nature,Mattias Jakobsson,2025-12-03,False,True,False,28
 10.1038/s41586-025-09799-x,Ancient DNA from Shimao city records kinship practices in Neolithic China,2025,Nature,Zehui Chen,2025-11-26,False,False,False,144
 10.1016/j.jasrep.2025.105474,Ancient genomic evidence uncovers a 6th-century cross-border couple between South Asia and East Asia,2025,Journal of Archaeological Science: Reports,Panxin Du,2025-11-05,False,False,False,2
-10.1038/s41586-025-09731-3,Eight millennia of continuity of a previously unknown lineage in Argentina,2026,Nature,Javier Maravall-López,2025-11-05,False,False,False,238
-10.1101/2025.11.03.686206,"Genetic insights into Iron Age Saka culture: Ancient DNA analysis of the Boz-Barmak burial ground, Kyrgyzstan",0,No Journal,Aigerim Rymbekova,2025-11-04,False,False,False,9
-10.1126/sciadv.adu9625,Dynamic human admixture histories over the past ~1300 years at the northern Himalayan frontier,2025,Science Advances,Esha Bandyopadhyay,2025-10-29,False,False,False,8
+10.1038/s41586-025-09731-3,Eight millennia of continuity of a previously unknown lineage in Argentina,2026,Nature,Javier Maravall-López,2025-11-05,False,True,False,238
+10.1101/2025.11.03.686206,"Genetic insights into Iron Age Saka culture: Ancient DNA analysis of the Boz-Barmak burial ground, Kyrgyzstan",0,No Journal,Aigerim Rymbekova,2025-11-04,False,True,False,9
+10.1126/sciadv.adu9625,Dynamic human admixture histories over the past ~1300 years at the northern Himalayan frontier,2025,Science Advances,Esha Bandyopadhyay,2025-10-29,False,True,False,8
 10.1038/s41598-025-21522-4,Genome of an early Okhotsk individual reveals ancient admixture between Jomon and Kamchatka lineages,2025,Scientific Reports,Takehiro Sato,2025-10-27,False,False,False,1
 10.1016/j.fsigen.2025.103381,"Murder in cold blood? Forensic and bioarchaeological identification of the skeletal remains of Béla, Duke of Macsó (c. 1245–1272)",2026,Forensic Science International: Genetics,Tamás Hajdu,2025-10-26,False,False,False,1
 10.1016/j.cub.2025.09.047,Paratyphoid fever and relapsing fever in 1812 Napoleon's devastated army,2025,Current Biology,Rémi Barbieri,2025-10-24,False,False,False,13
-10.1016/j.cell.2025.09.002,Long shared haplotypes identify the southern Urals as a primary source for the 10th-century Hungarians,2025,Cell,Balázs Gyuris,2025-10-16,False,False,False,131
+10.1016/j.cell.2025.09.002,Long shared haplotypes identify the southern Urals as a primary source for the 10th-century Hungarians,2025,Cell,Balázs Gyuris,2025-10-16,False,True,False,131
 10.1371/journal.pone.0333440,"Multidisciplinary study of human remains from the 3rd century mass grave in the Roman city of Mursa, Croatia",2025,PLOS One,Mario Novak,2025-10-15,False,False,False,7
 10.1126/sciadv.adw8219,Ancient genomes from eastern Kazakhstan reveal dynamic genetic legacy of Inner Eurasian hunter-gatherers,2025,Science Advances,Haechan Gill,2025-10-15,False,False,False,21
-10.1038/s41467-025-63743-1,Ancient DNA reveals the population interactions and a Neolithic patrilineal community in Northern Yangtze Region,2025,Nature Communications,Tingyu Yang,2025-09-30,False,False,False,58
+10.1038/s41467-025-63743-1,Ancient DNA reveals the population interactions and a Neolithic patrilineal community in Northern Yangtze Region,2025,Nature Communications,Tingyu Yang,2025-09-30,False,True,False,58
 10.1038/s41467-025-63789-1,Slab Grave expansion disrupted long co-existence of distinct Bronze Age herders in central Mongolia,2025,Nature Communications,Juhyeon Lee,2025-09-25,False,False,False,30
 10.1038/s41586-025-09437-6,Ancient DNA connects large-scale migration with the spread of Slavs,2025,Nature,Joscha Gretzinger,2025-09-03,True,False,False,555
 10.1186/s13059-025-03700-9,Ancient genomes provide evidence of demographic shift to Slavic-associated groups in Moravia,2025,Genome Biology,Ilektra Schulz,2025-09-03,False,False,False,18
 10.1038/s42003-025-08668-7,Genomic insights from a final Bronze Age community buried in a collective tumulus in an Urnfield settlement in Northeastern Iberia,2025,Communications Biology,Marina Bretos Ezcurra,2025-08-28,False,False,False,24
 10.1126/sciadv.adq9976,Local increases in admixture with hunter-gatherers followed the initial expansion of Neolithic farmers across continental Europe,2025,Science Advances,Alexandros Tsoupas,2025-08-20,False,False,False,0
-10.1186/s13059-025-03707-2,"The genetic history of Portugal over the past 5,000 years",2025,Genome Biology,Xavier Roca-Rada,2025-08-18,False,False,False,67
+10.1186/s13059-025-03707-2,"The genetic history of Portugal over the past 5,000 years",2025,Genome Biology,Xavier Roca-Rada,2025-08-18,False,True,False,67
 10.15184/aqy.2025.10139,West African ancestry in seventh-century England: two individuals from Kent and Dorset,2025,Antiquity,Duncan Sayer,2025-08-13,False,False,False,2
 10.1016/j.cell.2025.07.013,"The genetic history of the Southern Caucasus from the Bronze Age to the Early Middle Ages: 5,000 years of genetic continuity despite high mobility",2025,Cell,Eirini Skourtanioti,2025-08-07,True,False,False,230
 10.1093/gbe/evaf149,A New Perspective on the Arrival of the Eastern Mediterranean Genetic Influx in Central Italy Before the Onset of the Roman Empire,2025,Genome Biology and Evolution,Francesco Ravasini,2025-07-26,False,False,False,1
@@ -41,45 +41,45 @@ doi,title,year,journal,first_author,publication_date,community_archive,aadr_arch
 10.1016/j.cub.2025.06.054,Bronze and Iron Age genomes reveal the integration of diverse ancestries in the Tarim Basin,2025,Current Biology,Fan Zhang,2025-07-17,False,False,False,24
 10.1016/j.isci.2025.113086,Archaeogenetics reveals fine-scale genetic continuity and patterns of kinship and health in medieval Finland,2025,iScience,Ulla Nordfors,2025-07-15,False,False,False,21
 10.1038/s41467-025-61601-8,Genomic diversity and structure of prehistoric alpine individuals from the Tyrolean Iceman’s territory,2025,Nature Communications,Myriam Croze,2025-07-11,False,False,False,47
-10.1038/s41586-025-09195-5,Whole-genome ancestry of an Old Kingdom Egyptian,2025,Nature,Adeline Morez Jacobs,2025-07-02,False,False,False,1
-10.1038/s41586-025-09189-3,Ancient DNA reveals the prehistory of the Uralic and Yeniseian peoples,2025,Nature,Tian Chen Zeng,2025-07-02,False,False,False,195
-10.1126/science.adr2915,Female lineages and changing kinship patterns in Neolithic Çatalhöyük,2025,Science,Eren Yüncü,2025-06-26,True,False,False,131
+10.1038/s41586-025-09195-5,Whole-genome ancestry of an Old Kingdom Egyptian,2025,Nature,Adeline Morez Jacobs,2025-07-02,False,True,False,1
+10.1038/s41586-025-09189-3,Ancient DNA reveals the prehistory of the Uralic and Yeniseian peoples,2025,Nature,Tian Chen Zeng,2025-07-02,False,True,False,195
+10.1126/science.adr2915,Female lineages and changing kinship patterns in Neolithic Çatalhöyük,2025,Science,Eren Yüncü,2025-06-26,True,True,False,131
 10.1126/science.adr3326,Out-of-Anatolia: Cultural and genetic interactions during the Neolithic expansion in the Aegean,2025,Science,Dilek Koptekin,2025-06-26,False,False,False,30
-10.1038/s41467-025-60368-2,Ancient DNA reveals diverse community organizations in the 5th millennium BCE Carpathian Basin,2025,Nature Communications,Anna Szécsényi-Nagy,2025-06-24,False,False,False,125
+10.1038/s41467-025-60368-2,Ancient DNA reveals diverse community organizations in the 5th millennium BCE Carpathian Basin,2025,Nature Communications,Anna Szécsényi-Nagy,2025-06-24,False,True,False,125
 10.1016/j.isci.2025.112871,"Genetic transitions in the Neolithic and Bronze Age at Mas d’en Boixos (Catalonia, Spain)",2025,iScience,Xavier Roca-Rada,2025-06-11,False,False,False,8
 10.1016/j.cell.2025.05.009,Unveiling the origins and genetic makeup of the “forgotten people”: A study of the Sarmatian-period population in the Carpathian Basin,2025,Cell,Oszkár Schütz,2025-06-10,False,False,True,156
 10.1038/s41586-025-09103-x,Ancient DNA reveals a two-clanned matrilineal community in Neolithic China,2025,Nature,Jincheng Wang,2025-06-04,False,False,False,60
-10.1038/s41559-025-02710-x,"The impact of human dispersals and local interactions on the genetic diversity of coastal Papua New Guinea over the past 2,500 years",2025,Nature Ecology &amp; Evolution,Kathrin Nägele,2025-06-04,True,False,False,27
+10.1038/s41559-025-02710-x,"The impact of human dispersals and local interactions on the genetic diversity of coastal Papua New Guinea over the past 2,500 years",2025,Nature Ecology &amp; Evolution,Kathrin Nägele,2025-06-04,True,True,False,27
 10.1126/science.adk5081,From North Asia to South America: Tracing the longest human migration through genomic sequencing,2025,Science,Elena S. Gusareva,2025-05-29,False,False,False,0
-10.1186/s13059-025-03580-z,Urbanization and genetic homogenization in the medieval Low Countries revealed through a ten-century paleogenomic study of the city of Sint-Truiden,2025,Genome Biology,Owyn Beneker,2025-05-19,False,False,False,338
-10.1038/s41598-025-99743-w,"Ancient DNA indicates 3,000 years of genetic continuity in the Northern Iranian Plateau, from the Copper Age to the Sassanid Empire",2025,Scientific Reports,Motahareh Ala Amjadi,2025-05-13,True,False,False,20
+10.1186/s13059-025-03580-z,Urbanization and genetic homogenization in the medieval Low Countries revealed through a ten-century paleogenomic study of the city of Sint-Truiden,2025,Genome Biology,Owyn Beneker,2025-05-19,False,True,False,338
+10.1038/s41598-025-99743-w,"Ancient DNA indicates 3,000 years of genetic continuity in the Northern Iranian Plateau, from the Copper Age to the Sassanid Empire",2025,Scientific Reports,Motahareh Ala Amjadi,2025-05-13,True,True,False,20
 10.1186/s13059-025-03570-1,Medieval genomes from eastern Iberia illuminate the role of Morisco mass deportations in dismantling a long-standing genetic bridge with North Africa,2025,Genome Biology,Gonzalo Oteo-Garcia,2025-04-28,False,False,False,12
-10.1038/s41586-025-08913-3,Punic people were genetically diverse with almost no Levantine ancestors,2025,Nature,Harald Ringbauer,2025-04-23,False,False,False,210
+10.1038/s41586-025-08913-3,Punic people were genetically diverse with almost no Levantine ancestors,2025,Nature,Harald Ringbauer,2025-04-23,False,True,False,210
 10.1038/s41586-025-08793-7,Ancient DNA from the Green Sahara reveals ancestral North African lineage,2025,Nature,Nada Salem,2025-04-04,False,False,False,2
-10.1038/s41586-024-08531-5,The genetic origin of the Indo-Europeans,2025,Nature,Iosif Lazaridis,2025-02-05,True,False,False,354
-10.1038/s41467-025-56555-w,East Asian Gene flow bridged by northern coastal populations over past 6000 years,2025,Nature Communications,Juncen Liu,2025-02-03,False,False,False,85
-10.1038/s41586-024-08418-5,Ancient DNA reveals reproductive barrier despite shared Avar-period culture,2025,Nature,Ke Wang,2025-01-15,True,False,False,722
-10.1038/s41586-024-08409-6,Continental influx and pervasive matrilocality in Iron Age Britain,2025,Nature,Lara M. Cassidy,2025-01-15,False,False,False,57
-10.1126/sciadv.adr0695,North Pontic crossroads: Mobility in Ukraine from the Bronze Age to the early modern period,2025,Science Advances,Lehti Saag,2025-01-08,True,False,False,91
+10.1038/s41586-024-08531-5,The genetic origin of the Indo-Europeans,2025,Nature,Iosif Lazaridis,2025-02-05,True,True,False,354
+10.1038/s41467-025-56555-w,East Asian Gene flow bridged by northern coastal populations over past 6000 years,2025,Nature Communications,Juncen Liu,2025-02-03,False,True,False,85
+10.1038/s41586-024-08418-5,Ancient DNA reveals reproductive barrier despite shared Avar-period culture,2025,Nature,Ke Wang,2025-01-15,True,True,False,722
+10.1038/s41586-024-08409-6,Continental influx and pervasive matrilocality in Iron Age Britain,2025,Nature,Lara M. Cassidy,2025-01-15,False,True,False,57
+10.1126/sciadv.adr0695,North Pontic crossroads: Mobility in Ukraine from the Bronze Age to the early modern period,2025,Science Advances,Lehti Saag,2025-01-08,True,True,False,91
 10.1073/pnas.2412355121,The genetic origins and impacts of historical Papuan migrations into Wallacea,2024,Proceedings of the National Academy of Sciences,Gludhug A. Purnomo,2024-12-17,False,False,False,0
 10.1038/s41562-024-02034-z,Social and genetic diversity in first farmers of central Europe,2024,Nature Human Behaviour,Pere Gelabert,2024-11-29,False,True,False,250
-10.1186/s12915-024-02068-9,Ancient genomes from the Tang Dynasty capital reveal the genetic legacy of trans-Eurasian communication at the eastern end of Silk Road,2024,BMC Biology,Minglei Lv,2024-11-20,False,False,False,7
-10.1186/s13059-024-03430-4,The genomic portrait of the Picene culture provides new insights into the Italic Iron Age and the legacy of the Roman Empire in Central Italy,2024,Genome Biology,Francesco Ravasini,2024-11-20,True,False,False,102
-10.1038/s41586-024-08113-5,The rise and transformation of Bronze Age pastoralists in the Caucasus,2024,Nature,Ayshin Ghalichi,2024-10-30,True,False,False,131
+10.1186/s12915-024-02068-9,Ancient genomes from the Tang Dynasty capital reveal the genetic legacy of trans-Eurasian communication at the eastern end of Silk Road,2024,BMC Biology,Minglei Lv,2024-11-20,False,True,False,7
+10.1186/s13059-024-03430-4,The genomic portrait of the Picene culture provides new insights into the Italic Iron Age and the legacy of the Roman Empire in Central Italy,2024,Genome Biology,Francesco Ravasini,2024-11-20,True,True,False,102
+10.1038/s41586-024-08113-5,The rise and transformation of Bronze Age pastoralists in the Caucasus,2024,Nature,Ayshin Ghalichi,2024-10-30,True,True,False,131
 10.1101/2024.05.29.596386,Ancient genomes reveal Avar-Hungarian transformations in the 9th-10th centuries CE Carpathian Basin,2024,bioRxiv,Dániel Gerber,2024-10-28,False,True,False,1
-10.1038/s41467-024-51150-x,"Life history and ancestry of the late Upper Palaeolithic infant from Grotta delle Mura, Italy",2024,Nature Communications,Owen Alexander Higgins,2024-09-20,True,False,False,1
+10.1038/s41467-024-51150-x,"Life history and ancestry of the late Upper Palaeolithic infant from Grotta delle Mura, Italy",2024,Nature Communications,Owen Alexander Higgins,2024-09-20,True,True,False,1
 10.1093/molbev/msae168,Low Genetic Impact of the Roman Occupation of Britain in Rural Communities,2024,Molecular Biology and Evolution,Christiana L Scheib,2024-09-13,False,False,False,52
 10.1038/s41586-024-07881-4,Ancient Rapanui genomes reveal resilience and pre-European contact with the Americas,2024,Nature,J. Víctor Moreno-Mayar,2024-09-11,False,False,False,15
-10.1016/j.xgen.2024.100593,Long genetic and social isolation in Neanderthals before their extinction,2024,Cell Genomics,Ludovic Slimak,2024-09-11,False,False,False,1
-10.1126/sciadv.adp8625,"Five centuries of consanguinity, isolation, health, and conflict in Las Gobas: A Northern Medieval Iberian necropolis",2024,Science Advances,Ricardo Rodríguez-Varela,2024-08-28,False,False,False,33
+10.1016/j.xgen.2024.100593,Long genetic and social isolation in Neanderthals before their extinction,2024,Cell Genomics,Ludovic Slimak,2024-09-11,False,True,False,1
+10.1126/sciadv.adp8625,"Five centuries of consanguinity, isolation, health, and conflict in Las Gobas: A Northern Medieval Iberian necropolis",2024,Science Advances,Ricardo Rodríguez-Varela,2024-08-28,False,True,False,33
 10.1007/s12520-024-02050-0,"Bioarchaeological Perspectives on Late Antiquity in Dalmatia: Paleogenetic, Dietary, and Population Studies of the Hvar—Radošević burial site",2024,Archaeological and Anthropological Sciences,Brina Zagorc,2024-08-20,False,True,False,24
 10.1016/j.cub.2024.07.063,Genomic dynamics of the Lower Yellow River Valley since the Early Neolithic,2024,Current Biology,Panxin Du,2024-08-14,False,False,False,69
 10.15184/aqy.2024.94,"High levels of consanguinity in a child from Paquimé, Chihuahua, Mexico",2024,Antiquity,Jakob Sedig,2024-08-13,False,True,False,1
-10.1038/s41467-024-51087-1,Human genetic structure in Northwest France provides new insights into West European historical demography,2024,Nature Communications,Isabel Alves,2024-08-07,False,False,False,6
+10.1038/s41467-024-51087-1,Human genetic structure in Northwest France provides new insights into West European historical demography,2024,Nature Communications,Isabel Alves,2024-08-07,False,True,False,6
 10.1007/s12520-024-02036-y,Ancient genomes provide insights into the genetic history in the historical era of southwest China,2024,Archaeological and Anthropological Sciences,Fan Zhang,2024-07-17,False,True,False,14
 10.1038/s41586-024-07651-2,Repeated plague infections across six generations of Neolithic Farmers,2024,Nature,Frederik Valeur Seersholm,2024-07-10,False,True,False,239
-10.1073/pnas.2406734121,Capturing the fusion of two ancestries and kinship structures in Merovingian Flanders,2024,Proceedings of the National Academy of Sciences,Stefania Sasso,2024-06-24,False,False,True,48
-10.1126/sciadv.adl2468,Late Neolithic collective burial reveals admixture dynamics during the third millennium BCE and the shaping of the European genome,2024,Science Advances,Oğuzhan Parasayan,2024-06-19,False,False,False,8
+10.1073/pnas.2406734121,Capturing the fusion of two ancestries and kinship structures in Merovingian Flanders,2024,Proceedings of the National Academy of Sciences,Stefania Sasso,2024-06-24,False,True,True,48
+10.1126/sciadv.adl2468,Late Neolithic collective burial reveals admixture dynamics during the third millennium BCE and the shaping of the European genome,2024,Science Advances,Oğuzhan Parasayan,2024-06-19,False,True,False,8
 10.1038/s41586-024-07509-7,Ancient genomes reveal insights into ritual life at Chichén Itzá,2024,Nature,Rodrigo Barquera,2024-06-12,True,True,False,56
 10.1038/s41562-024-01888-7,Evidence for dynastic succession among early Celtic elites in Central Europe,2024,Nature Human Behaviour,Joscha Gretzinger,2024-06-03,True,True,False,58
 10.1038/s41598-024-61052-z,"Bioarchaeology aids the cultural understanding of six characters in search of their agency (Tarquinia, ninth–seventh century BC, central Italy)",2024,Scientific Reports,G. Bagnasco,2024-05-28,False,True,False,12
@@ -89,8 +89,8 @@ doi,title,year,journal,first_author,publication_date,community_archive,aadr_arch
 10.1073/pnas.2310545121,Genomic ancestry and social dynamics of the last hunter-gatherers of Atlantic France,2024,Proceedings of the National Academy of Sciences,Luciana G. Simões,2024-02-26,False,True,True,10
 10.1038/s41598-024-54824-0,Biomolecular evidence for changing millet reliance in Late Bronze Age central Germany,2024,Scientific Reports,Eleftheria Orfanou,2024-02-22,False,False,False,0
 10.1038/s41598-024-54462-6,Kinship practices at the early bronze age site of Leubingen in Central Germany,2024,Scientific Reports,Sandra Penske,2024-02-16,True,True,False,48
-10.1038/s41559-024-02322-x,Medieval DNA from Soqotra points to Eurasian origins of an isolated population at the crossroads of Africa and Arabia,2024,Nature Ecology &amp; Evolution,Kendra Sirak,2024-02-08,False,False,False,39
-10.1126/sciadv.adi5903,Genetic history of Cambridgeshire before and after the Black Death,2024,Science Advances,Ruoyun Hui,2024-01-17,False,False,False,275
+10.1038/s41559-024-02322-x,Medieval DNA from Soqotra points to Eurasian origins of an isolated population at the crossroads of Africa and Arabia,2024,Nature Ecology &amp; Evolution,Kendra Sirak,2024-02-08,False,True,False,39
+10.1126/sciadv.adi5903,Genetic history of Cambridgeshire before and after the Black Death,2024,Science Advances,Ruoyun Hui,2024-01-17,False,True,False,275
 10.1038/s41586-023-06618-z,Elevated genetic risk for multiple sclerosis emerged in steppe pastoralist populations,2024,Nature,William Barrie,2024-01-10,False,True,False,85
 10.1038/s41586-023-06865-0,Population genomics of post-glacial western Eurasia,2024,Nature,Morten E. Allentoft,2024-01-10,True,True,False,631
 10.1038/s41467-023-44328-2,Genomic portrait and relatedness patterns of the Iron Age Log Coffin culture in northwestern Thailand,2023,Nature Communications,Selina Carlhoff,2023-12-22,True,True,False,33
@@ -102,9 +102,9 @@ doi,title,year,journal,first_author,publication_date,community_archive,aadr_arch
 10.1073/pnas.2303574120,"Descent, marriage, and residence practices of a 3,800-year-old pastoral community in Central Eurasia",2023,Proceedings of the National Academy of Sciences,Jens Blöcher,2023-08-21,False,True,False,32
 10.1038/s41559-023-02143-4,A genetic history of continuity and mobility in the Iron Age central Mediterranean,2023,Nature Ecology &amp; Evolution,Hannah M. Moots,2023-08-17,False,True,False,28
 10.1016/j.xgen.2023.100377,High-coverage genome of the Tyrolean Iceman reveals unusually high Anatolian farmer ancestry,2023,Cell Genomics,Ke Wang,2023-08-16,False,True,False,1
-10.1038/s41467-023-40198-w,The genomic history of the indigenous people of the Canary Islands,2023,Nature Communications,Javier G. Serrano,2023-08-15,False,False,False,40
+10.1038/s41467-023-40198-w,The genomic history of the indigenous people of the Canary Islands,2023,Nature Communications,Javier G. Serrano,2023-08-15,False,True,False,40
 10.1038/s42003-023-05131-3,"Genetic continuity, isolation, and gene flow in Stone Age Central and Eastern Europe",2023,Communications Biology,Tiina M. Mattila,2023-08-09,False,True,False,72
-10.1093/molbev/msad182,Interdisciplinary Analyses of Bronze Age Communities from Western Hungary Reveal Complex Population Histories,2023,Molecular Biology and Evolution,Dániel Gerber,2023-08-09,False,False,False,21
+10.1093/molbev/msad182,Interdisciplinary Analyses of Bronze Age Communities from Western Hungary Reveal Complex Population Histories,2023,Molecular Biology and Evolution,Dániel Gerber,2023-08-09,False,True,False,21
 10.1126/science.ade4995,The genetic legacy of African Americans from Catoctin Furnace,2023,Science,Éadaoin Harney,2023-08-08,False,True,False,27
 10.1038/s41467-023-40072-9,Patrilocality and hunter-gatherer-related ancestry of populations in East-Central Europe during the Middle Bronze Age,2023,Nature Communications,Maciej Chyleński,2023-08-01,False,True,False,1
 10.1038/s41559-023-02114-9,Genomic history of coastal societies from eastern South America,2023,Nature Ecology &amp; Evolution,Tiago Ferraz,2023-07-31,False,True,True,34
@@ -116,7 +116,7 @@ doi,title,year,journal,first_author,publication_date,community_archive,aadr_arch
 10.1371/journal.pone.0285449,Interactions between Trypillian farmers and North Pontic forager-pastoralists in Eneolithic central Ukraine,2023,PLOS ONE,Alexey G. Nikitin,2023-06-14,False,True,False,1
 10.1038/s41586-023-06166-6,Northwest African Neolithic initiated by migrants from Iberia and Levant,2023,Nature,Luciana G. Simões,2023-06-07,False,True,False,9
 10.1126/science.add6142,Demographic history and genetic structure in pre-Hispanic Central Mexico,2023,Science,Viridiana Villa-Islas,2023-05-11,True,True,True,12
-10.1371/journal.pgen.1010360,"Imputed genomes and haplotype-based analyses of the Picts of early medieval Scotland reveal fine-scale relatedness between Iron Age, early medieval and the modern people of the UK",2023,PLOS Genetics,Adeline Morez,2023-04-27,False,False,False,2
+10.1371/journal.pgen.1010360,"Imputed genomes and haplotype-based analyses of the Picts of early medieval Scotland reveal fine-scale relatedness between Iron Age, early medieval and the modern people of the UK",2023,PLOS Genetics,Adeline Morez,2023-04-27,False,True,False,2
 10.7554/elife.85492,On the limits of fitting complex models of population history to f-statistics,2023,eLife,Robert Maier,2023-04-14,True,True,False,1
 10.1016/j.isci.2023.106581,A paleogenome from a Holocene individual supports genetic continuity in Southeast Alaska,2023,iScience,Alber Aqil,2023-04-09,False,False,False,1
 10.1038/s41586-023-05754-w,Entwined African and Asian genetic roots of medieval peoples of the Swahili coast,2023,Nature,Esther S. Brielle,2023-03-29,False,True,False,80
@@ -127,7 +127,7 @@ doi,title,year,journal,first_author,publication_date,community_archive,aadr_arch
 10.1038/s41586-023-05726-0,Palaeogenomics of Upper Palaeolithic to Neolithic European hunter-gatherers,2023,Nature,Cosimo Posth,2023-03-01,False,True,False,162
 10.15184/aqy.2023.2,"Kinship practices in Early Iron Age South-east Europe: genetic and isotopic analysis of burials from the Dolge njive barrow cemetery, Dolenjska, Slovenia",2023,Antiquity,Ian Armit,2023-02-17,False,True,False,9
 10.1073/pnas.2210611120,Isotopic and DNA analyses reveal multiscale PPNB mobility and migration across Southeastern Anatolia and the Southern Levant,2023,Proceedings of the National Academy of Sciences,Xiaoran Wang,2023-01-17,True,True,False,7
-10.1038/s41559-022-01952-3,Ancient DNA reveals admixture history and endogamy in the prehistoric Aegean,2023,Nature Ecology &amp; Evolution,Eirini Skourtanioti,2023-01-16,True,False,False,103
+10.1038/s41559-022-01952-3,Ancient DNA reveals admixture history and endogamy in the prehistoric Aegean,2023,Nature Ecology &amp; Evolution,Eirini Skourtanioti,2023-01-16,True,True,False,103
 10.1016/j.cub.2022.11.062,Middle Holocene Siberian genomes reveal highly connected gene pools throughout North Asia,2023,Current Biology,Ke Wang,2023-01-12,False,True,False,10
 10.1016/j.cell.2022.11.024,The genetic history of Scandinavia from the Roman Iron Age to the present,2023,Cell,Ricardo Rodríguez-Varela,2023-01-05,False,True,True,158
 10.1038/s41598-022-26799-3,Ancient DNA from Protohistoric Period Cambodia indicates that South Asians admixed with local populations as early as 1st–3rd centuries CE,2022,Scientific Reports,Piya Changmai,2022-12-29,False,True,False,1

--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,11 @@
+## What does this script do?
+This script reads a list of DOIs from `list.csv`, fetches metadata from **CrossRef API**, and checks if those papers exist in **Poseidon Archives** (`community-archive`, `aadr-archive`, `minotaur-archive`). It then generates an **HTML table (`index.html`)**.
 
-
-## 💡 What does this script do?
-This script reads a list of DOIs from `list.txt`, fetches metadata from **CrossRef API**, and checks if those papers exist in **Poseidon Archives** (`community-archive`, `aadr-archive`, `minotaur-archive`). It then generates an **HTML table (`index.html`)** displaying:
-
-✔ Paper title  
-✔ Publication year & exact date  
-✔ First author’s name  
-✔ Journal name  
-✔ Availability in Poseidon archives (✔ or ✘)  
-✔ A **search bar** for filtering by title  
-✔ **Dropdown filters** for the archives  
-
-Every time `list.txt` is updated and a commit is pushed, this script runs and updates `index.html` on GitHub Pages.
+Every time `list.csv` is updated and a commit is pushed, this script runs and updates `index.html` on GitHub Pages.
 
 ---
 
-## ⚙️ Technical Requirements
+## Technical Requirements
 - **Python Version:** Python 3.x  
 - **Required Libraries:**  
   ```bash
@@ -27,71 +17,6 @@ Every time `list.txt` is updated and a commit is pushed, this script runs and up
   - `index.html` → The generated output file  
 
 ---
-
-## 🔍 How the Functions Work
-
-### 1️⃣ `get_crossref_metadata(doi, index, total)`
-Fetches metadata from CrossRef API.  
-Extracts **title, year, journal, date, first author’s name**.  
-Formats publication date into **YYYY-MM-DD**.  
-Prints **progress updates** like:  
-   ```
-   (1 / 100) Querying metadata for 10.1002/ajpa.23312
-   ```
-   
-### 2️⃣ `fetch_poseidon_bibliography(archive_name)`
-Calls Poseidon API to check available DOIs for a given archive.  
-Extracts **DOI list** from `community-archive`, `aadr-archive`, and `minotaur-archive`.  
-Prints **status messages** while fetching:  
-   ```
-   Fetching DOI data from community-archive...
-   ```
-
-### 3️⃣ `load_poseidon_doi_map()`
-Collects all available DOIs from **all Poseidon archives**.  
-Stores data in a dictionary mapping **DOIs → available archives**.
-
-### 4️⃣ `preprocess_doi(doi)`
-Cleans up DOI format by removing extra spaces & "https://doi.org/".
-
-### 5️⃣ `check_for_duplicates(dois)`
-Checks `list.txt` for duplicate DOIs.  
-If duplicates are found, it **prints a warning**:  
-   ```
-   WARNING: Duplicate DOIs found:
-   - 10.1002/ajpa.23312
-   ```
-
-### 6️⃣ `generate_html(papers, output_file)`
-Creates **index.html** using a **Jinja2 template**.  
-Adds search bar to filter by **title**.  
-Adds dropdown filters to show/hide papers based on Poseidon archive availability.  
-Formats clickable DOI links like this:  
-   ```
-   <a href="https://doi.org/10.1002/ajpa.23312">10.1002/ajpa.23312</a>
-   ```
-Prints progress while updating:  
-   ```
-   Updating index.html...
-   index.html successfully updated!
-   ```
-
----
-
-## 🚀 How to Run the Script
-1. Add **DOIs** to `list.txt` (one per line).  
-2. Run the script:  
-   ```bash
-   python base_script.py
-   ```
-3. Open `index.html` to see the results!  
-
----
-
-This is a **fully automated workflow** that updates the table and deploys it to **GitHub Pages** whenever `input.txt` changes.
-
-**GitHub Actions Workflow** runs everything behind the scenes. No manual updates needed!
-
 
 ## Testing locally
 


### PR DESCRIPTION
When updating the directory to reflect the new state of the AADR archive I quickly asked ChatGPT to add a caching feature for the crossref data. Just to avoid the constant redownloading.